### PR TITLE
Json object as transfer meta field

### DIFF
--- a/accounting/prisma/migrations/20250623135421_json_transfer_meta/migration.sql
+++ b/accounting/prisma/migrations/20250623135421_json_transfer_meta/migration.sql
@@ -1,0 +1,6 @@
+-- This migration changes the "meta" column in the "Transfer" table from TEXT to JSONB.
+-- It initializes the new JSONB column with a default object containing a "description" field.
+
+ALTER TABLE "Transfer"
+ALTER COLUMN "meta" TYPE JSONB
+USING jsonb_build_object('description', "meta"::text);

--- a/accounting/prisma/schema.prisma
+++ b/accounting/prisma/schema.prisma
@@ -166,7 +166,7 @@ model Transfer {
 
   state  String @default("new") @db.VarChar(31)
   amount BigInt
-  meta   String @db.Text
+  meta   Json
 
   hash String? @db.VarChar(255)
 

--- a/accounting/src/controller/transfer-controller.ts
+++ b/accounting/src/controller/transfer-controller.ts
@@ -51,6 +51,15 @@ export class TransferController  extends AbstractCurrencyController implements I
         throw badRequest("Invalid authorization")
       }
     }
+    // Backwards compatibility for meta field.
+    if (typeof data.meta === "string") {
+      data.meta = {
+        description: data.meta
+      }
+    }
+    if (!data.meta || typeof data.meta !== "object" || typeof data.meta.description !== "string") {
+      throw badRequest("Transfer meta must be an object with a description string")
+    }
   }
 
   /**

--- a/accounting/src/model/transfer.ts
+++ b/accounting/src/model/transfer.ts
@@ -3,6 +3,8 @@ import { FullAccount, Account, AccountRecord, recordToAccount } from "./account"
 import { Transfer as TransferRecord, ExternalTransfer as ExternalTransferRecord } from "@prisma/client"
 import { Currency, User } from "."
 import { ExternalResource, ExternalResourceRecord, recordToExternalResource, RelatedResource } from "./resource"
+import { JsonValue } from "@prisma/client/runtime/library"
+import { internalError } from "../utils/error"
 
 export { TransferRecord }
 
@@ -36,6 +38,11 @@ export type TransferAuthorization = {
   hash?: string
 }
 
+export type TransferMeta = {
+  description: string
+  [key: string]: any
+}
+
 /**
  * Transfer object as returned by the API, with some fields omitted due to access permissions.
  */
@@ -49,7 +56,7 @@ export interface FullTransfer {
 
   state: TransferState
   amount: number
-  meta: string
+  meta: TransferMeta
 
   hash?: string
 
@@ -70,6 +77,18 @@ export interface FullTransfer {
 export type InputTransfer = AtLeast<Omit<FullTransfer, "created" | "updated" | "payer" | "payee">, "amount" | "meta" | "state"> & {payer: RelatedResource, payee: RelatedResource}
 export type UpdateTransfer = AtLeast<Omit<FullTransfer, "created" | "updated" | "payer" | "payee"> & {payer: RelatedResource, payee: RelatedResource}, "id">
 
+
+const metaJson = (meta: JsonValue) : TransferMeta => {
+  if (typeof meta === "object" && !Array.isArray(meta) && meta && typeof meta.description === "string") {
+    return {
+      ...meta,
+      description: meta.description,
+    }
+  }
+  throw internalError("Invalid meta format from database", {
+    details: meta
+  })
+}
 export const recordToTransfer = (record: TransferRecord, accounts: {
   payer: FullAccount, 
   payee: FullAccount,
@@ -79,7 +98,7 @@ export const recordToTransfer = (record: TransferRecord, accounts: {
   id: record.id,
   state: record.state as TransferState,
   amount: Number(record.amount),
-  meta: record.meta,
+  meta: metaJson(record.meta),
   hash: record.hash ?? undefined,
   authorization: record.authorization as TransferAuthorization ?? undefined,
   created: record.created,

--- a/accounting/src/model/transfer.ts
+++ b/accounting/src/model/transfer.ts
@@ -3,7 +3,7 @@ import { FullAccount, Account, AccountRecord, recordToAccount } from "./account"
 import { Transfer as TransferRecord, ExternalTransfer as ExternalTransferRecord } from "@prisma/client"
 import { Currency, User } from "."
 import { ExternalResource, ExternalResourceRecord, recordToExternalResource, RelatedResource } from "./resource"
-import { JsonValue } from "@prisma/client/runtime/library"
+import { Prisma } from "@prisma/client";
 import { internalError } from "../utils/error"
 
 export { TransferRecord }
@@ -78,7 +78,7 @@ export type InputTransfer = AtLeast<Omit<FullTransfer, "created" | "updated" | "
 export type UpdateTransfer = AtLeast<Omit<FullTransfer, "created" | "updated" | "payer" | "payee"> & {payer: RelatedResource, payee: RelatedResource}, "id">
 
 
-const metaJson = (meta: JsonValue) : TransferMeta => {
+const metaJson = (meta: Prisma.JsonValue) : TransferMeta => {
   if (typeof meta === "object" && !Array.isArray(meta) && meta && typeof meta.description === "string") {
     return {
       ...meta,

--- a/accounting/src/server/validation.ts
+++ b/accounting/src/server/validation.ts
@@ -146,7 +146,7 @@ export namespace Validators {
   ]
 
   const isCreateTransferAttributes = (path: string) => [
-    body(`${path}.meta`).isString(),
+    body(`${path}.meta.description`).isString(),
     body(`${path}.amount`).isInt({gt: 0}),
     body(`${path}.state`).isIn(["new", "committed"]),
     body(`${path}.hash`).optional().isString(),
@@ -195,7 +195,7 @@ export namespace Validators {
   ]
 
   const isUpdateTransferAttributes = (path: string) => [
-    body(`${path}.meta`).optional().isString(),
+    body(`${path}.meta.description`).optional().isString(),
     body(`${path}.amount`).optional().isInt({gt: 0}),
     body(`${path}.hash`).optional().isString(),
     body(`${path}.state`).optional().isIn(["new", "committed", "rejected", "deleted"]),

--- a/accounting/src/server/validation.ts
+++ b/accounting/src/server/validation.ts
@@ -146,7 +146,9 @@ export namespace Validators {
   ]
 
   const isCreateTransferAttributes = (path: string) => [
-    body(`${path}.meta.description`).isString(),
+    body(`${path}.meta`).custom((value => {
+      return value && typeof value === "object" && !Array.isArray(value) && typeof value.description === "string"
+    })),
     body(`${path}.amount`).isInt({gt: 0}),
     body(`${path}.state`).isIn(["new", "committed"]),
     body(`${path}.hash`).optional().isString(),
@@ -195,7 +197,9 @@ export namespace Validators {
   ]
 
   const isUpdateTransferAttributes = (path: string) => [
-    body(`${path}.meta.description`).optional().isString(),
+    body(`${path}.meta`).optional().custom((value => {
+      return value && typeof value === "object" && !Array.isArray(value) && typeof value.description === "string";
+    })),
     body(`${path}.amount`).optional().isInt({gt: 0}),
     body(`${path}.hash`).optional().isString(),
     body(`${path}.state`).optional().isIn(["new", "committed", "rejected", "deleted"]),

--- a/accounting/test/server/10.tag.transfer.api.test.ts
+++ b/accounting/test/server/10.tag.transfer.api.test.ts
@@ -93,7 +93,9 @@ describe('Preauthorized transfers with NFC tags', async () => {
       data: {
         attributes: {
           amount: 100,
-          meta: 'Transfer preauthorized with tag',
+          meta:{
+            description: 'Transfer preauthorized with tag'
+          },
           state: 'committed',
           authorization: {
             type: 'tag',
@@ -126,7 +128,9 @@ describe('Preauthorized transfers with NFC tags', async () => {
       data: {
         attributes: {
           amount: 100,
-          meta: 'Transfer preauthorized with tag',
+          meta: {
+            description: 'Transfer preauthorized with tag',
+          },
           state: 'committed',
           authorization: {
             type: 'tag',
@@ -144,7 +148,9 @@ describe('Preauthorized transfers with NFC tags', async () => {
       data: {
         attributes: {
           amount: 100,
-          meta: 'Transfer preauthorized with tag',
+          meta: {
+            description: 'Transfer preauthorized with tag',
+          },
           state: 'committed',
           authorization: {
             type: 'tag',

--- a/accounting/test/server/3.transfer.api.test.ts
+++ b/accounting/test/server/3.transfer.api.test.ts
@@ -14,7 +14,7 @@ describe('Transfer endpoints', async () => {
   await it('user performs payment', async () => {
     const transfer = await t.payment(t.account1.id, t.account2.id, 100, "User transfer", "committed", t.user1)
     assert.equal(transfer.attributes.amount, 100)
-    assert.equal(transfer.attributes.meta, "User transfer")
+    assert.equal(transfer.attributes.meta.description, "User transfer")
     assert.equal(transfer.attributes.state, "committed")
     assert.equal(transfer.relationships.payer.data.id, t.account1.id)
     assert.equal(transfer.relationships.payee.data.id, t.account2.id)
@@ -58,7 +58,7 @@ describe('Transfer endpoints', async () => {
     }, t.user1)
     const transfer2 = response2.body.data
     assert.equal(transfer2.attributes.state, "committed")
-    assert.equal(transfer2.attributes.meta, "Two-step transfer")
+    assert.equal(transfer2.attributes.meta.description, "Two-step transfer")
     assert.equal(transfer2.attributes.amount, 30)
 
     //balance changed
@@ -121,7 +121,9 @@ describe('Transfer endpoints', async () => {
       data: { 
         attributes: { 
           amount: 200,
-          meta: "Updated transfer",
+          meta: {
+            description: "Updated transfer",
+          }
         },
         relationships: {
           payee: { data: { type: "accounts", id: t.account0.id } }
@@ -130,7 +132,7 @@ describe('Transfer endpoints', async () => {
     }, t.user1)
     const updatedTransfer = response.body.data
     assert.equal(updatedTransfer.attributes.amount, 200)
-    assert.equal(updatedTransfer.attributes.meta, "Updated transfer")
+    assert.equal(updatedTransfer.attributes.meta.description, "Updated transfer")
     assert.equal(updatedTransfer.attributes.state, "new")
     assert.equal(updatedTransfer.relationships.payee.data.id, t.account0.id)
   })
@@ -169,7 +171,7 @@ describe('Transfer endpoints', async () => {
     const fetchedTransfer = response.body.data
     assert.equal(fetchedTransfer.id, transfer.id)
     assert.equal(fetchedTransfer.attributes.amount, 100)
-    assert.equal(fetchedTransfer.attributes.meta, "Get transfer")
+    assert.equal(fetchedTransfer.attributes.meta.description, "Get transfer")
     assert.equal(fetchedTransfer.attributes.state, "new")
     assert.equal(fetchedTransfer.relationships.payer.data.id, t.account1.id)
     assert.equal(fetchedTransfer.relationships.payee.data.id, t.account2.id)
@@ -190,7 +192,7 @@ describe('Transfer endpoints', async () => {
     assert.equal(norl(response.body.links.next), norl("/TEST/transfers?page[size]=3&sort=-created&page[after]=3"))
     const transfers = response.body.data
     // Last transfer
-    assert.equal(transfers[0].attributes.meta, "Get transfer")
+    assert.equal(transfers[0].attributes.meta.description, "Get transfer")
     assert.equal(transfers[0].attributes.amount, 100)
     assert.equal(transfers[0].attributes.state, "new")
     assert.equal(transfers[0].relationships.payer.data.id, t.account1.id)

--- a/accounting/test/server/8.external.transfer.api.test.ts
+++ b/accounting/test/server/8.external.transfer.api.test.ts
@@ -25,8 +25,8 @@ describe("External transfers", async () => {
   let eAccount1: any
   let eTrustline: any
 
-  const externalTransfer = async (currency: any, externalCurrency: any, payer: any, payee: any, amount: number, meta: string, state: string, auth: any, httpStatus = 201) => {
-    const transfer = testTransfer(payer.id, payee.id, amount, meta, state)
+  const externalTransfer = async (currency: any, externalCurrency: any, payer: any, payee: any, amount: number, description: string, state: string, auth: any, httpStatus = 201) => {
+    const transfer = testTransfer(payer.id, payee.id, amount, description, state)
     if (payer.relationships.currency.data.id !== currency.id) {
       (transfer.data.relationships.payer.data as any).meta = { 
         external: true, 
@@ -132,7 +132,7 @@ describe("External transfers", async () => {
 
     const checkTransfer = (transfer: any, test: boolean) => {
       assert.equal(transfer.attributes.amount, test ? 100 : 20)
-      assert.equal(transfer.attributes.meta, "TEST => EXTR")
+      assert.equal(transfer.attributes.meta.description, "TEST => EXTR")
       assert.equal(transfer.attributes.state, "committed")
       assert.equal(transfer.relationships.payer.data.id, t.account1.id)
       assert.equal(transfer.relationships.payee.data.id, eAccount1.id)

--- a/accounting/test/server/api.data.ts
+++ b/accounting/test/server/api.data.ts
@@ -46,11 +46,13 @@ export const testAccount = (userId: string) => ({
   included: [{ type: "users", id: userId }]
 })
 
-export const testTransfer = (payerId: string, payeeId: string, amount: number, meta: string, state: string) => ({
+export const testTransfer = (payerId: string, payeeId: string, amount: number, description: string, state: string) => ({
   data: {
     attributes: {
       amount,
-      meta,
+      meta: {
+        description
+      },
       state
     },
     relationships: {

--- a/accounting/test/server/db.ts
+++ b/accounting/test/server/db.ts
@@ -124,7 +124,9 @@ export async function seedTransfers(tenantId: string, n: number, start: Date, en
         amount,
         payerId: payer.id,
         payeeId: payee.id,
-        meta: text,
+        meta: {
+          description: text,
+        },
         userId: "0",
         state: r(0, 10) > 0 ? "committed" : "rejected",
         created,

--- a/accounting/test/server/setup.ts
+++ b/accounting/test/server/setup.ts
@@ -14,7 +14,7 @@ interface TestSetup {
   app: ExpressExtended,
   api: TestApiClient,
   createAccount: (user: string, code?: string, admin?: UserAuth) => Promise<any>,
-  payment: (payer: string, payee: string, amount: number, meta: string, state: string, auth: any, httpStatus?: number) => Promise<any>,
+  payment: (payer: string, payee: string, amount: number, description: string, state: string, auth: any, httpStatus?: number) => Promise<any>,
 }
 
 interface TestSetupWithCurrency extends TestSetup {
@@ -48,8 +48,8 @@ export function setupServerTest(createData: boolean = true): TestSetupWithCurren
       return response.body.data
     },
 
-    payment: async (payer: string, payee: string, amount: number, meta: string, state: string, auth: any, httpStatus = 201) => {
-      const response = await test.api?.post('/TEST/transfers', testTransfer(payer, payee, amount, meta, state), auth, httpStatus)
+    payment: async (payer: string, payee: string, amount: number, description: string, state: string, auth: any, httpStatus = 201) => {
+      const response = await test.api?.post('/TEST/transfers', testTransfer(payer, payee, amount, description, state), auth, httpStatus)
       return response.body.data
     }
   }

--- a/accounting/test/unit/1.validation.test.ts
+++ b/accounting/test/unit/1.validation.test.ts
@@ -77,7 +77,9 @@ describe('Input validation', async () => {
         attributes: {
           state: "committed",
           amount: 100,
-          meta: "hello",
+          meta: {
+            description: "hello",
+          }
         },
         relationships: {
           payer: { data: {id: "3bc8e447-32cb-4dc7-b7ec-6a6f33c6c99e", type: "accounts"} },

--- a/app/src/components/TransactionCard.vue
+++ b/app/src/components/TransactionCard.vue
@@ -41,7 +41,7 @@
         {{ $formatDate(transfer.attributes.updated) }}
       </div>
       <div class="text-body1">
-        {{ transfer.attributes.meta }}
+        {{ transfer.attributes.meta.description }}
       </div>
     </q-card-section>
     <q-separator />

--- a/app/src/components/TransactionItem.vue
+++ b/app/src/components/TransactionItem.vue
@@ -10,7 +10,7 @@
       v-if="$q.screen.lt.md" 
       #caption
     >
-      {{ transfer.attributes.meta.description }}
+      {{ description }}
     </template>
     <template 
       v-if="$q.screen.gt.sm" 
@@ -18,7 +18,7 @@
     >
       <q-item-section class="section-extra">
         <q-item-label lines="2">
-          {{ transfer.attributes.meta.description }}
+          {{ description }}
         </q-item-label>
       </q-item-section>
     </template>
@@ -87,6 +87,10 @@ const otherAccount = (transfer: ExtendedTransfer): Account => {
   // We can't directly compare object references because they're not the same.
   const other = props.account.id == transfer.relationships.payer.data.id ? payee : payer
   return other
+}
+
+const description = (transfer: ExtendedTransfer): string => {
+  return transfer.attributes.meta.description || "";
 }
 
 </script>

--- a/app/src/components/TransactionItem.vue
+++ b/app/src/components/TransactionItem.vue
@@ -1,6 +1,6 @@
 <template>
   <account-header
-    :account="otherAccount(transfer)"
+    :account="otherAccount"
     :clickable="!!transfer.id"
     class="transaction-item"
     :class="transfer.attributes.state"
@@ -44,18 +44,19 @@
         <div
           class="col transaction-amount text-h6"
           :class="
-            signedAmount(transfer) >= 0
+            signedAmount >= 0
               ? 'positive-amount'
               : 'negative-amount'
           "
         >
-          {{ FormatCurrency(signedAmount(transfer), account.currency) }}
+          {{ FormatCurrency(signedAmount, account.currency) }}
         </div>
       </div>
     </template>
   </account-header>
 </template>
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Account, Currency, ExtendedTransfer } from 'src/store/model';
 import FormatCurrency from "../plugins/FormatCurrency";
 import AccountHeader from "./AccountHeader.vue";
@@ -76,22 +77,20 @@ const props = defineProps<{
   
 }>()
 
-const signedAmount = (transfer: ExtendedTransfer): number => {
-  const amount = transfer.attributes.amount
-  return (transfer.relationships.payer.data.id == props.account.id ? -1 : 1) * amount;
-}
+const signedAmount = computed<number>(() => {
+  const amount = props.transfer.attributes.amount
+  return (props.transfer.relationships.payer.data.id == props.account.id ? -1 : 1) * amount;
+})
 
-const otherAccount = (transfer: ExtendedTransfer): Account => {
-  const payer = transfer.payer
-  const payee = transfer.payee
+const otherAccount = computed<Account>(() => {
+  const payer = props.transfer.payer
+  const payee = props.transfer.payee
   // We can't directly compare object references because they're not the same.
-  const other = props.account.id == transfer.relationships.payer.data.id ? payee : payer
+  const other = props.account.id == props.transfer.relationships.payer.data.id ? payee : payer
   return other
-}
+})
 
-const description = (transfer: ExtendedTransfer): string => {
-  return transfer.attributes.meta.description || "";
-}
+const description = computed(() => props.transfer.attributes.meta.description || "")
 
 </script>
 <style lang="scss" scoped>

--- a/app/src/components/TransactionItem.vue
+++ b/app/src/components/TransactionItem.vue
@@ -10,7 +10,7 @@
       v-if="$q.screen.lt.md" 
       #caption
     >
-      {{ transfer.attributes.meta }}
+      {{ transfer.attributes.meta.description }}
     </template>
     <template 
       v-if="$q.screen.gt.sm" 
@@ -18,7 +18,7 @@
     >
       <q-item-section class="section-extra">
         <q-item-label lines="2">
-          {{ transfer.attributes.meta }}
+          {{ transfer.attributes.meta.description }}
         </q-item-label>
       </q-item-section>
     </template>

--- a/app/src/pages/settings/DeleteMemberBtn.vue
+++ b/app/src/pages/settings/DeleteMemberBtn.vue
@@ -107,7 +107,9 @@ const deleteMember = async () => {
         attributes: {
           amount: Math.abs(balance),
           state: "committed",
-          meta: t('setZeroBalance')
+          meta: {
+            description: t('setZeroBalance')
+          }
         },
         relationships: transferAccountRelationships(payer, payee, currency)
       }

--- a/app/src/pages/transactions/CreateTransactionMultipleConfirm.vue
+++ b/app/src/pages/transactions/CreateTransactionMultipleConfirm.vue
@@ -72,7 +72,9 @@ watch(() => props.rows, () => {
       type: "transfers",
       attributes: {
         amount: transferAmount(row.amount as number),
-        meta: row.description,
+        meta: {
+          description: row.description,
+        },
         created: new Date().toUTCString(),
         updated: new Date().toUTCString(),
         state: "new"

--- a/app/src/pages/transactions/CreateTransactionReceiveNFC.vue
+++ b/app/src/pages/transactions/CreateTransactionReceiveNFC.vue
@@ -41,7 +41,7 @@
               {{ FormatCurrency(editTransfer.attributes.amount, myCurrency) }}
             </div>
             <div class="text-body1">
-              {{ editTransfer.attributes.meta }}
+              {{ editTransfer.attributes.meta.description }}
             </div>
           </q-card-section>
         </q-card>

--- a/app/src/pages/transactions/CreateTransactionReceiveQR.vue
+++ b/app/src/pages/transactions/CreateTransactionReceiveQR.vue
@@ -35,7 +35,7 @@
               {{ FormatCurrency(transfer.attributes.amount, currency) }}
             </div>
             <div class="text-body1">
-              {{ transfer.attributes.meta }}
+              {{ transfer.attributes.meta.description }}
             </div>
           </q-card-section>
         </q-card>
@@ -90,7 +90,7 @@ const qrData = computed(() => {
   const query = new URLSearchParams()
   query.set("t", transfer.value?.payee.links.self ?? "")
   query.set("a", transfer.value?.attributes.amount.toString() ?? "")
-  query.set("m", transfer.value?.attributes.meta ?? "")
+  query.set("m", transfer.value?.attributes.meta.description ?? "")
   return `${base}/pay?${query.toString()}`
 })
 </script>

--- a/app/src/pages/transactions/CreateTransactionSendQR.vue
+++ b/app/src/pages/transactions/CreateTransactionSendQR.vue
@@ -66,18 +66,18 @@ const parsePaymentUrl = (paymentUrl: string) => {
   const url = new URL(paymentUrl)
   const payeeHref = url.searchParams.get("t")
   const amount = url.searchParams.get("a")
-  const meta = url.searchParams.get("m")
+  const description = url.searchParams.get("m")
 
   if (!payeeHref || !amount) {
     throw new KError(KErrorCode.QRCodeError, "Invalid transfer URL")
   }
 
-  return { payeeHref, amount, meta } 
+  return { payeeHref, amount, description } 
 }
 
 const onPaymentUrl = async (paymentUrl: string) => {
   try {
-    const {payeeHref, amount, meta} = parsePaymentUrl(paymentUrl)
+    const {payeeHref, amount, description} = parsePaymentUrl(paymentUrl)
 
     await store.dispatch("accounts/load", {
       url: payeeHref,
@@ -101,7 +101,9 @@ const onPaymentUrl = async (paymentUrl: string) => {
       type: "transfers",
       attributes: {
         amount: localAmount,
-        meta: meta ?? "",
+        meta: {
+          description: description ?? ""
+        },
         state: "new",
         created: new Date().toISOString(),
         updated: new Date().toISOString(),

--- a/app/src/pages/transactions/CreateTransactionSingleForm.vue
+++ b/app/src/pages/transactions/CreateTransactionSingleForm.vue
@@ -124,7 +124,7 @@ const transfer = computed({
 
 const payerAccountValue = ref(props.payerAccount)
 const payeeAccountValue = ref(props.payeeAccount)
-const concept = ref(props.modelValue?.attributes?.meta ?? "")
+const concept = ref(props.modelValue?.attributes?.meta?.description ?? "")
 const amount = ref<number|undefined>(props.modelValue?.attributes?.amount ? props.modelValue.attributes.amount / Math.pow(10, myCurrency.value.attributes.scale) : undefined)
 
 // Validation.
@@ -177,7 +177,9 @@ const onSubmit = () => {
     type: "transfers",
     attributes: {
       amount: transferAmount,
-      meta: concept.value,
+      meta: {
+        description: concept.value,
+      },
       state: "new",
       created: new Date().toUTCString(),
       updated: new Date().toUTCString(),

--- a/app/src/server/AccountingServer.ts
+++ b/app/src/server/AccountingServer.ts
@@ -110,7 +110,9 @@ export default {
     }),
     transfer: Factory.extend({
       amount: () => faker.random.number({min: 0.1*10000, max: 100*10000, precision: 100}),
-      meta: () => faker.company.catchPhrase(),
+      meta: () => ({
+        description: faker.company.catchPhrase(),
+      }),
       state: (i: number) => (i < 3 ? "pending" : (i % 8 == 0) ? "rejected" : "committed"),
       created: (i: number) => faker.date.recent(i % 5).toJSON(),
       updated: (i: number) => faker.date.recent(i % 5).toJSON(),

--- a/app/src/server/ServerUtils.ts
+++ b/app/src/server/ServerUtils.ts
@@ -7,7 +7,7 @@ export function search(records: any, request: any) {
     records = records.filter((record: any) =>
       Object.values(record.attrs).some(
         (value: any) => {
-          value && JSON.stringify(value).toLowerCase().includes(fragment.toLowerCase())
+          return value && JSON.stringify(value).toLowerCase().includes(fragment.toLowerCase())
         }
       ) 
       // Special case for members and account codes.

--- a/app/src/server/ServerUtils.ts
+++ b/app/src/server/ServerUtils.ts
@@ -6,7 +6,9 @@ export function search(records: any, request: any) {
     const fragment = request.queryParams["filter[search]"];
     records = records.filter((record: any) =>
       Object.values(record.attrs).some(
-        (value: any) => value && value.toString().toLowerCase().includes(fragment.toLowerCase())
+        (value: any) => {
+          value && JSON.stringify(value).toLowerCase().includes(fragment.toLowerCase())
+        }
       ) 
       // Special case for members and account codes.
       || (record.account?.attrs.code.toLowerCase().includes(fragment.toLowerCase()))

--- a/app/src/store/model.ts
+++ b/app/src/store/model.ts
@@ -400,10 +400,11 @@ export interface AccountSettings extends ResourceObject {
 }
 
 export type TransferState = "new" | "pending" | "accepted" | "committed" | "rejected" | "failed" | "deleted"
+export type AnyJson = string | number | boolean | null | { [key: string]: AnyJson } | AnyJson[];
+
 export type TransferMeta = {
   description: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
+  [key: string]: AnyJson;
 };
 
 export interface Transfer extends ResourceObject {

--- a/app/src/store/model.ts
+++ b/app/src/store/model.ts
@@ -400,11 +400,16 @@ export interface AccountSettings extends ResourceObject {
 }
 
 export type TransferState = "new" | "pending" | "accepted" | "committed" | "rejected" | "failed" | "deleted"
+export type TransferMeta = {
+  description: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+};
 
 export interface Transfer extends ResourceObject {
   attributes: {
     amount: number,
-    meta: string,
+    meta: TransferMeta,
     state: TransferState;
     authorization?: {
       type: "tag",


### PR DESCRIPTION
Upgrade meta field in transfer objects from string to arbitrary json. That will allow extensions to save arbitrary data here, including credit commons protocol data, tagging, etc.