### PR TITLE
i18n: reword awkward transactionDescriptionHint (all languages)

### DIFF
--- a/app/src/i18n/ca/index.json
+++ b/app/src/i18n/ca/index.json
@@ -100,7 +100,7 @@
   "create": "Crea",
   "backToTransfers": "Torna a moviments",
   "description": "Descripció",
-  "transactionDescriptionHint": "Breu descripció del concepte de l'intercanvi. Per exemple '2kg de patates'.",
+  "transactionDescriptionHint": "Breu descripció d'allò que s'ha intercanviat, per exemple '2kg de patates'.",
   "amount": "Quantitat",
   "amountIn": "Quantitat en {currency}",
   "transactionAmountHint": "Quantitat de moneda a transferir",

--- a/app/src/i18n/en-us/index.json
+++ b/app/src/i18n/en-us/index.json
@@ -98,7 +98,7 @@
   "transactionPayerHint": "Choose the account from which the amount will be transferred.",
   "transactionPayeeHint": "Choose the account that will receive the transfer.",
   "description": "Description",
-  "transactionDescriptionHint": "Brief description of the concept of the exchange, for example '2kg of potatoes'.",
+  "transactionDescriptionHint": "Brief description of what was exchanged, for example '2kg of potatoes'.",
   "amount": "Amount",
   "amountIn": "Amount in {currency}",
   "transactionAmountHint": "Quantity to transfer.",

--- a/app/src/i18n/es/index.json
+++ b/app/src/i18n/es/index.json
@@ -100,7 +100,7 @@
   "transactionPayerHint": "Elige la cuenta desde la que se transferirá la cantidad.",
   "transactionPayeeHint": "Elige la cuenta que recibirá la transferencia.",
   "description": "Descripción",
-  "transactionDescriptionHint": "Breve descripción del concepto del intercambio. Por ejemplo '2kg de patatas'.",
+  "transactionDescriptionHint": "Breve descripción de lo que se ha intercambiado, por ejemplo '2kg de patatas'.",
   "amount": "Cantidad",
   "amountIn": "Cantidad en {currency}",
   "transactionAmountHint": "Cantidad a transferir",

--- a/app/src/i18n/fr/index.json
+++ b/app/src/i18n/fr/index.json
@@ -96,7 +96,7 @@
   "transactionPayerHint": "Choisissez le compte à partir duquel le montant sera transféré.",
   "transactionPayeeHint": "Choisissez le compte qui recevra le transfert.",
   "description": "Description",
-  "transactionDescriptionHint": "Brève description du motif du transfert, par exemple '2kg de pommes de terre'.",
+  "transactionDescriptionHint": "Brève description de ce qui a été échangé, par exemple '2kg de pommes de terre'.",
   "amount": "Montant",
   "amountIn": "Montant en {currency}",
   "transactionAmountHint": "Quantité à transférer.",

--- a/app/src/i18n/it/index.json
+++ b/app/src/i18n/it/index.json
@@ -100,7 +100,7 @@
   "create": "Crea",
   "backToTransfers": "Torna ai movimenti",
   "description": "Descrizione",
-  "transactionDescriptionHint": "Breve descrizione del concetto dello scambio. Per esempio '2kg di patate'.",
+  "transactionDescriptionHint": "Breve descrizione di ciò che è stato scambiato, per esempio '2kg di patate'.",
   "amount": "Importo",
   "amountIn": "Importo in {currency}",
   "transactionAmountHint": "Importo in {currency}.",


### PR DESCRIPTION
## What this does
Rewords the `transactionDescriptionHint` string, which read awkwardly in English and in its literal translations:

> ~~"Brief description of the concept of the exchange, for example '2kg of potatoes'."~~
> → **"Brief description of what was exchanged, for example '2kg of potatoes'."**

Applied consistently across all five languages (one line changed per file):

| Lang | New value |
|---|---|
| en-us | Brief description of what was exchanged, for example '2kg of potatoes'. |
| ca | Breu descripció d'allò que s'ha intercanviat, per exemple '2kg de patates'. |
| es | Breve descripción de lo que se ha intercambiado, por ejemplo '2kg de patatas'. |
| fr | Brève description de ce qui a été échangé, par exemple '2kg de pommes de terre'. |
| it | Breve descrizione di ciò che è stato scambiato, per esempio '2kg di patate'. |

This is a **base default-terminology** string — there is no CES flavour override for this key, so the fix improves every flavour at once.

## Note for @estevebadia
If you'd rather keep the original wording in the base languages, I'm happy to close this and instead open a PR that changes **only the CES flavour overrides** — just let me know your preference.

🤖 Fix prepared with [Claude Code](https://claude.com/claude-code).
