### PR TITLE
Member user preferences/2 social api

### DIFF
--- a/social/prisma/migrations/20260504160633_init/migration.sql
+++ b/social/prisma/migrations/20260504160633_init/migration.sql
@@ -4,7 +4,6 @@ CREATE TABLE "User" (
     "email" TEXT NOT NULL,
     "name" VARCHAR(255),
     "language" VARCHAR(31),
-    "settings" JSONB NOT NULL DEFAULT '{}',
     "created" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated" TIMESTAMP(3) NOT NULL,
 
@@ -81,7 +80,6 @@ CREATE TABLE "MemberUser" (
     "id" UUID NOT NULL,
     "memberId" UUID NOT NULL,
     "userId" UUID NOT NULL,
-    "role" VARCHAR(31) NOT NULL DEFAULT 'admin',
     "settings" JSONB NOT NULL DEFAULT '{"notifications":{"myAccount":true,"group":true},"emails":{"myAccount":true,"group":"monthly"}}',
 
     CONSTRAINT "MemberUser_pkey" PRIMARY KEY ("id")

--- a/social/prisma/schema.prisma
+++ b/social/prisma/schema.prisma
@@ -16,7 +16,6 @@ model User {
   email    String   @unique
   name     String?  @db.VarChar(255)
   language String?  @db.VarChar(31)
-  settings Json     @default("{}")
   created  DateTime @default(now())
   updated  DateTime @updatedAt
 
@@ -156,7 +155,6 @@ model MemberUser {
   id       String @id @default(uuid()) @db.Uuid
   memberId String @db.Uuid
   userId   String @db.Uuid
-  role     String @default("admin") @db.VarChar(31)
   settings Json   @default("{\"notifications\":{\"myAccount\":true,\"group\":true},\"emails\":{\"myAccount\":true,\"group\":\"monthly\"}}")
 
   member Member @relation(fields: [memberId, tenantId], references: [id, tenantId])

--- a/social/src/app.ts
+++ b/social/src/app.ts
@@ -12,6 +12,7 @@ import { tenantCategoryRoutes } from './features/categories/routes'
 import { tenantMemberRoutes } from './features/members/routes'
 import { tenantPostRoutes } from './features/posts/routes'
 import { tenantFileRoutes } from './features/files/routes'
+import { tenantMemberUserRoutes } from './features/member-users/routes'
 
 const app = express()
 
@@ -47,6 +48,7 @@ app.use('/', groupsRoutes)
 app.use('/:code', tenantGroupRoutes)
 app.use('/:code', tenantCategoryRoutes)
 app.use('/:code', tenantMemberRoutes)
+app.use('/:code', tenantMemberUserRoutes)
 app.use('/:code', tenantPostRoutes)
 app.use('/:code', tenantFileRoutes)
 

--- a/social/src/features/member-users/controller.ts
+++ b/social/src/features/member-users/controller.ts
@@ -1,0 +1,54 @@
+import type { RequestHandler } from 'express'
+import { getAuthContext } from '../../server/context'
+import { getCollectionSerializerOptions } from '../../server/jsonapi-serialize'
+import { getCode, getCollectionParams, getIdParam, getResourceParams } from '../../server/request'
+import { getValidatedBody } from '../../server/validation'
+import { badRequest } from '../../utils/error'
+import type { PatchMemberUserBody } from './schema'
+import { serializeMemberUser, serializeMemberUsers } from './serialize'
+import { getMemberUser, listMemberUsers, patchMemberUser } from './service'
+
+export const getMemberUsersRoute: RequestHandler = async (req, res) => {
+  const ctx = getAuthContext(req)
+  const code = getCode(req)
+  const params = getCollectionParams(req, {
+    filter: ['user', 'member'],
+    sort: ['id'],
+    include: ['user', 'member'],
+  })
+  const result = await listMemberUsers(ctx, code, params)
+  const payload = await serializeMemberUsers(
+    result.items,
+    getCollectionSerializerOptions(req.url, params, result.total),
+  )
+
+  res.status(200).json(payload)
+}
+
+export const getMemberUserRoute: RequestHandler = async (req, res) => {
+  const ctx = getAuthContext(req)
+  const code = getCode(req)
+  const id = getIdParam(req, 'id')
+  const params = getResourceParams(req, { include: ['user', 'member'] })
+  const relation = await getMemberUser(ctx, code, id, params)
+  const payload = await serializeMemberUser(relation, params)
+
+  res.status(200).json(payload)
+}
+
+export const patchMemberUserRoute: RequestHandler = async (req, res) => {
+  const ctx = getAuthContext(req)
+  const code = getCode(req)
+  const id = getIdParam(req, 'id')
+  const params = getResourceParams(req, { include: ['user', 'member'] })
+  const body = getValidatedBody<PatchMemberUserBody>(req)
+
+  if (body.data.id && body.data.id !== id) {
+    throw badRequest('Resource id does not match route id')
+  }
+
+  const relation = await patchMemberUser(ctx, code, id, body.data.attributes, params)
+  const payload = await serializeMemberUser(relation, params)
+
+  res.status(200).json(payload)
+}

--- a/social/src/features/member-users/routes.ts
+++ b/social/src/features/member-users/routes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express'
+import { userAuth } from '../../server/auth'
+import { Scope } from '../../server/scopes'
+import { validateBody } from '../../server/validation'
+import { getMemberUserRoute, getMemberUsersRoute, patchMemberUserRoute } from './controller'
+import { patchMemberUserBodySchema } from './schema'
+
+export const tenantMemberUserRoutes = Router({ mergeParams: true })
+
+tenantMemberUserRoutes.get('/member-users', userAuth(Scope.SocialRead), getMemberUsersRoute)
+tenantMemberUserRoutes.get('/member-users/:id', userAuth(Scope.SocialRead), getMemberUserRoute)
+tenantMemberUserRoutes.patch(
+  '/member-users/:id',
+  userAuth(Scope.SocialWrite),
+  validateBody(patchMemberUserBodySchema),
+  patchMemberUserRoute,
+)

--- a/social/src/features/member-users/schema.ts
+++ b/social/src/features/member-users/schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+import { jsonApiDocumentSchema, jsonApiResourceSchema } from '../../server/jsonapi-schema'
+
+export const memberUserSettingsAttributesSchema = z.object({
+  notifications: z.object({
+    myAccount: z.boolean().optional(),
+    group: z.boolean().optional(),
+  }).strict().optional(),
+  emails: z.object({
+    myAccount: z.boolean().optional(),
+    group: z.enum(['never', 'weekly', 'monthly']).optional(),
+  }).strict().optional(),
+}).strict()
+
+const memberUserSchema = jsonApiResourceSchema(
+  'member-users',
+  memberUserSettingsAttributesSchema,
+)
+
+export const patchMemberUserBodySchema = jsonApiDocumentSchema(memberUserSchema)
+
+export type PatchMemberUserBody = z.infer<typeof patchMemberUserBodySchema>

--- a/social/src/features/member-users/serialize.ts
+++ b/social/src/features/member-users/serialize.ts
@@ -1,0 +1,47 @@
+import TsJapi from 'ts-japi'
+import { getResourceLink, relatedResource, type SerializerOptions } from '../../server/jsonapi-serialize'
+import { MemberSerializer } from '../members/serialize'
+import type { SerializableMember } from '../members/types'
+import { UserSerializer } from '../users/serialize'
+import type { User } from '../users/types'
+import type { MemberUser, SerializableMemberUser } from './types'
+
+const { Linker, Relator, Serializer } = TsJapi
+
+const MemberUserSerializer = new Serializer<SerializableMemberUser>('member-users', {
+  version: null,
+  projection: {
+    notifications: 1,
+    emails: 1,
+  },
+  linkers: {
+    resource: new Linker((relation) => getResourceLink('member-users', relation.tenantId, relation.id)),
+  },
+  relators: {
+    member: new Relator<SerializableMemberUser, SerializableMember>(
+      async (relation) => relatedResource(relation.memberId, relation.member),
+      MemberSerializer,
+      { relatedName: 'member' },
+    ),
+    user: new Relator<SerializableMemberUser, User>(
+      async (relation) => relatedResource(relation.userId, relation.user),
+      UserSerializer,
+      { relatedName: 'user' },
+    ),
+  },
+})
+
+const toSerializable = (relation: MemberUser): SerializableMemberUser => ({
+  ...relation,
+  ...relation.settings,
+})
+
+export const serializeMemberUser = async (
+  relation: MemberUser,
+  options?: SerializerOptions<SerializableMemberUser>,
+) => MemberUserSerializer.serialize(toSerializable(relation), options)
+
+export const serializeMemberUsers = async (
+  relations: MemberUser[],
+  options?: SerializerOptions<SerializableMemberUser>,
+) => MemberUserSerializer.serialize(relations.map(toSerializable), options)

--- a/social/src/features/member-users/serialize.ts
+++ b/social/src/features/member-users/serialize.ts
@@ -4,7 +4,7 @@ import { MemberSerializer } from '../members/serialize'
 import type { SerializableMember } from '../members/types'
 import { UserSerializer } from '../users/serialize'
 import type { User } from '../users/types'
-import type { MemberUser, SerializableMemberUser } from './types'
+import type { EnrichedMemberUser, SerializableMemberUser } from './types'
 
 const { Linker, Relator, Serializer } = TsJapi
 
@@ -31,17 +31,17 @@ const MemberUserSerializer = new Serializer<SerializableMemberUser>('member-user
   },
 })
 
-const toSerializable = (relation: MemberUser): SerializableMemberUser => ({
+const toSerializable = (relation: EnrichedMemberUser): SerializableMemberUser => ({
   ...relation,
   ...relation.settings,
 })
 
 export const serializeMemberUser = async (
-  relation: MemberUser,
+  relation: EnrichedMemberUser,
   options?: SerializerOptions<SerializableMemberUser>,
 ) => MemberUserSerializer.serialize(toSerializable(relation), options)
 
 export const serializeMemberUsers = async (
-  relations: MemberUser[],
+  relations: EnrichedMemberUser[],
   options?: SerializerOptions<SerializableMemberUser>,
 ) => MemberUserSerializer.serialize(relations.map(toSerializable), options)

--- a/social/src/features/member-users/service.ts
+++ b/social/src/features/member-users/service.ts
@@ -1,17 +1,19 @@
 import { z } from 'zod'
-import type { Prisma } from '../../generated/prisma/client'
+import type { MemberUser as DbMemberUser, Prisma } from '../../generated/prisma/client'
 import type { AuthContext } from '../../server/context'
 import { tenantDb } from '../../server/multitenant'
-import type { CollectionResult } from '../../server/query'
-import { indexById } from '../../server/query'
+import { indexById, type CollectionResult, uniqueById } from '../../server/query'
 import { getFilter, hasInclude, type CollectionParams, type ResourceParams } from '../../server/request'
 import { forbidden, notFound } from '../../utils/error'
 import prisma from '../../utils/prisma'
 import { getGroupByCode, isGroupAdmin } from '../groups/service'
+import type { Group } from '../groups/types'
 import { enrichMembers, toMember } from '../members/service'
+import type { Member } from '../members/types'
 import { toUser } from '../users/service'
+import type { User } from '../users/types'
 import { mergeMemberUserSettings, type MemberUserSettings, type MemberUserSettingsPatch } from './settings'
-import type { MemberUser } from './types'
+import type { EnrichedMemberUser, MemberUser } from './types'
 
 const uuidSchema = z.uuid()
 
@@ -23,31 +25,40 @@ const getAuthorization = async (ctx: AuthContext, code: string) => {
   }
 }
 
-const hydrateMemberUsers = async (
+export const toMemberUser = (
+  memberUser: DbMemberUser,
+  member?: Member,
+  user?: User,
+): MemberUser => ({
+  ...memberUser,
+  settings: memberUser.settings as MemberUserSettings,
+  member,
+  user,
+})
+
+export const enrichMemberUsers = async (
   ctx: AuthContext,
-  code: string,
-  rows: any[],
-  params: ResourceParams,
-): Promise<MemberUser[]> => {
-  const includeMembers = hasInclude(params, 'member')
-  const members = includeMembers
-    ? await enrichMembers(
-        ctx,
-        rows.map(({ member }: any) => toMember(member)),
-        [(await getGroupByCode(ctx, code))],
-      )
-    : []
+  memberUsers: MemberUser[],
+  group: Group,
+): Promise<EnrichedMemberUser[]> => {
+  const includedMembers = uniqueById(
+    memberUsers.flatMap(({ member }) => member ? [member] : []),
+  )
+  const members = await enrichMembers(ctx, includedMembers, [group])
   const membersById = indexById(members)
 
-  return rows.map((row) => ({
-    id: row.id,
-    tenantId: row.tenantId,
-    memberId: row.memberId,
-    userId: row.userId,
-    settings: row.settings as MemberUserSettings,
-    member: membersById.get(row.memberId),
-    user: row.user ? toUser(row.user) : undefined,
+  return memberUsers.map((memberUser) => ({
+    ...memberUser,
+    member: memberUser.member ? membersById.get(memberUser.memberId)! : undefined,
   }))
+}
+
+export const enrichMemberUser = async (
+  ctx: AuthContext,
+  memberUser: MemberUser,
+  group: Group,
+): Promise<EnrichedMemberUser> => {
+  return (await enrichMemberUsers(ctx, [memberUser], group))[0]
 }
 
 const getLoad = (params: ResourceParams) => ({
@@ -55,12 +66,43 @@ const getLoad = (params: ResourceParams) => ({
   user: hasInclude(params, 'user'),
 })
 
+const getAuthorizedMemberUser = async (
+  ctx: AuthContext,
+  code: string,
+  id: string,
+  params: ResourceParams,
+) => {
+  const { group, canReadAll } = await getAuthorization(ctx, code)
+  const db = tenantDb(prisma, code)
+  const load = getLoad(params)
+  const row = await db.memberUser.findUnique({
+    where: { id },
+    include: load,
+  })
+
+  if (!row) {
+    throw notFound('Member-user relation not found')
+  }
+  if (!canReadAll && row.userId !== ctx.userId) {
+    throw forbidden('You can only access your own member-user relations')
+  }
+
+  return {
+    group,
+    memberUser: toMemberUser(
+      row,
+      load.member ? toMember(row.member) : undefined,
+      load.user ? toUser(row.user) : undefined,
+    ),
+  }
+}
+
 export const listMemberUsers = async (
   ctx: AuthContext,
   code: string,
   params: CollectionParams,
-): Promise<CollectionResult<MemberUser>> => {
-  const { canReadAll } = await getAuthorization(ctx, code)
+): Promise<CollectionResult<EnrichedMemberUser>> => {
+  const { group, canReadAll } = await getAuthorization(ctx, code)
   const userIds = getFilter(params, 'user', uuidSchema)
   const memberIds = getFilter(params, 'member', uuidSchema)
 
@@ -79,10 +121,11 @@ export const listMemberUsers = async (
   }
 
   const order = params.sort[0]?.order ?? 'asc'
+  const load = getLoad(params)
   const [rows, total] = await Promise.all([
     db.memberUser.findMany({
       where,
-      include: getLoad(params),
+      include: load,
       orderBy: { id: order },
       skip: params.pagination.cursor,
       take: params.pagination.size,
@@ -90,8 +133,14 @@ export const listMemberUsers = async (
     db.memberUser.count({ where }),
   ])
 
+  const items = rows.map((row) => toMemberUser(
+    row,
+    load.member ? toMember(row.member) : undefined,
+    load.user ? toUser(row.user) : undefined,
+  ))
+
   return {
-    items: await hydrateMemberUsers(ctx, code, rows, params),
+    items: await enrichMemberUsers(ctx, items, group),
     total,
   }
 }
@@ -101,22 +150,9 @@ export const getMemberUser = async (
   code: string,
   id: string,
   params: ResourceParams,
-): Promise<MemberUser> => {
-  const { canReadAll } = await getAuthorization(ctx, code)
-  const db = tenantDb(prisma, code)
-  const row = await db.memberUser.findUnique({
-    where: { id },
-    include: getLoad(params),
-  })
-
-  if (!row) {
-    throw notFound('Member-user relation not found')
-  }
-  if (!canReadAll && row.userId !== ctx.userId) {
-    throw forbidden('You can only access your own member-user relations')
-  }
-
-  return (await hydrateMemberUsers(ctx, code, [row], params))[0]
+): Promise<EnrichedMemberUser> => {
+  const { group, memberUser } = await getAuthorizedMemberUser(ctx, code, id, params)
+  return enrichMemberUser(ctx, memberUser, group)
 }
 
 export const patchMemberUser = async (
@@ -125,16 +161,28 @@ export const patchMemberUser = async (
   id: string,
   patch: MemberUserSettingsPatch,
   params: ResourceParams,
-): Promise<MemberUser> => {
-  const current = await getMemberUser(ctx, code, id, { include: [] })
+): Promise<EnrichedMemberUser> => {
+  const { group, memberUser: current } = await getAuthorizedMemberUser(
+    ctx,
+    code,
+    id,
+    { include: [] },
+  )
   const db = tenantDb(prisma, code)
+  const load = getLoad(params)
   const row = await db.memberUser.update({
     where: { id },
     data: {
       settings: mergeMemberUserSettings(current.settings, patch),
     },
-    include: getLoad(params),
+    include: load,
   })
 
-  return (await hydrateMemberUsers(ctx, code, [row], params))[0]
+  const memberUser = toMemberUser(
+    row,
+    load.member ? toMember(row.member) : undefined,
+    load.user ? toUser(row.user) : undefined,
+  )
+
+  return enrichMemberUser(ctx, memberUser, group)
 }

--- a/social/src/features/member-users/service.ts
+++ b/social/src/features/member-users/service.ts
@@ -4,8 +4,8 @@ import type { AuthContext } from '../../server/context'
 import { tenantDb } from '../../server/multitenant'
 import type { CollectionResult } from '../../server/query'
 import { indexById } from '../../server/query'
-import { hasInclude, type CollectionParams, type ResourceParams } from '../../server/request'
-import { badRequest, forbidden, notFound } from '../../utils/error'
+import { getFilter, hasInclude, type CollectionParams, type ResourceParams } from '../../server/request'
+import { forbidden, notFound } from '../../utils/error'
 import prisma from '../../utils/prisma'
 import { getGroupByCode, isGroupAdmin } from '../groups/service'
 import { enrichMembers, toMember } from '../members/service'
@@ -14,18 +14,6 @@ import { mergeMemberUserSettings, type MemberUserSettings, type MemberUserSettin
 import type { MemberUser } from './types'
 
 const uuidSchema = z.uuid()
-
-const getFilter = (params: CollectionParams, name: 'user' | 'member') => {
-  const values = params.filters[name]
-  if (values) {
-    for (const value of values) {
-      if (!uuidSchema.safeParse(value).success) {
-        throw badRequest(`Invalid ${name} filter`)
-      }
-    }
-  }
-  return values
-}
 
 const getAuthorization = async (ctx: AuthContext, code: string) => {
   const group = await getGroupByCode(ctx, code)
@@ -73,8 +61,8 @@ export const listMemberUsers = async (
   params: CollectionParams,
 ): Promise<CollectionResult<MemberUser>> => {
   const { canReadAll } = await getAuthorization(ctx, code)
-  const userIds = getFilter(params, 'user')
-  const memberIds = getFilter(params, 'member')
+  const userIds = getFilter(params, 'user', uuidSchema)
+  const memberIds = getFilter(params, 'member', uuidSchema)
 
   if (!canReadAll && userIds?.some((id) => id !== ctx.userId)) {
     throw forbidden('You can only access your own member-user relations')

--- a/social/src/features/member-users/service.ts
+++ b/social/src/features/member-users/service.ts
@@ -1,0 +1,152 @@
+import { z } from 'zod'
+import type { Prisma } from '../../generated/prisma/client'
+import type { AuthContext } from '../../server/context'
+import { tenantDb } from '../../server/multitenant'
+import type { CollectionResult } from '../../server/query'
+import { indexById } from '../../server/query'
+import { hasInclude, type CollectionParams, type ResourceParams } from '../../server/request'
+import { badRequest, forbidden, notFound } from '../../utils/error'
+import prisma from '../../utils/prisma'
+import { getGroupByCode, isGroupAdmin } from '../groups/service'
+import { enrichMembers, toMember } from '../members/service'
+import { toUser } from '../users/service'
+import { mergeMemberUserSettings, type MemberUserSettings, type MemberUserSettingsPatch } from './settings'
+import type { MemberUser } from './types'
+
+const uuidSchema = z.uuid()
+
+const getFilter = (params: CollectionParams, name: 'user' | 'member') => {
+  const values = params.filters[name]
+  if (values) {
+    for (const value of values) {
+      if (!uuidSchema.safeParse(value).success) {
+        throw badRequest(`Invalid ${name} filter`)
+      }
+    }
+  }
+  return values
+}
+
+const getAuthorization = async (ctx: AuthContext, code: string) => {
+  const group = await getGroupByCode(ctx, code)
+  return {
+    group,
+    canReadAll: ctx.isSuperadmin || ctx.canReadAllSocial || isGroupAdmin(ctx, group),
+  }
+}
+
+const hydrateMemberUsers = async (
+  ctx: AuthContext,
+  code: string,
+  rows: any[],
+  params: ResourceParams,
+): Promise<MemberUser[]> => {
+  const includeMembers = hasInclude(params, 'member')
+  const members = includeMembers
+    ? await enrichMembers(
+        ctx,
+        rows.map(({ member }: any) => toMember(member)),
+        [(await getGroupByCode(ctx, code))],
+      )
+    : []
+  const membersById = indexById(members)
+
+  return rows.map((row) => ({
+    id: row.id,
+    tenantId: row.tenantId,
+    memberId: row.memberId,
+    userId: row.userId,
+    settings: row.settings as MemberUserSettings,
+    member: membersById.get(row.memberId),
+    user: row.user ? toUser(row.user) : undefined,
+  }))
+}
+
+const getLoad = (params: ResourceParams) => ({
+  member: hasInclude(params, 'member'),
+  user: hasInclude(params, 'user'),
+})
+
+export const listMemberUsers = async (
+  ctx: AuthContext,
+  code: string,
+  params: CollectionParams,
+): Promise<CollectionResult<MemberUser>> => {
+  const { canReadAll } = await getAuthorization(ctx, code)
+  const userIds = getFilter(params, 'user')
+  const memberIds = getFilter(params, 'member')
+
+  if (!canReadAll && userIds?.some((id) => id !== ctx.userId)) {
+    throw forbidden('You can only access your own member-user relations')
+  }
+
+  const where: Prisma.MemberUserWhereInput = {
+    ...(!canReadAll ? { userId: ctx.userId } : userIds ? { userId: { in: userIds } } : {}),
+    ...(memberIds ? { memberId: { in: memberIds } } : {}),
+  }
+  const db = tenantDb(prisma, code)
+
+  if (!canReadAll && await db.memberUser.count({ where: { userId: ctx.userId } }) === 0) {
+    throw forbidden('You do not have access to member-user relations in this group')
+  }
+
+  const order = params.sort[0]?.order ?? 'asc'
+  const [rows, total] = await Promise.all([
+    db.memberUser.findMany({
+      where,
+      include: getLoad(params),
+      orderBy: { id: order },
+      skip: params.pagination.cursor,
+      take: params.pagination.size,
+    }),
+    db.memberUser.count({ where }),
+  ])
+
+  return {
+    items: await hydrateMemberUsers(ctx, code, rows, params),
+    total,
+  }
+}
+
+export const getMemberUser = async (
+  ctx: AuthContext,
+  code: string,
+  id: string,
+  params: ResourceParams,
+): Promise<MemberUser> => {
+  const { canReadAll } = await getAuthorization(ctx, code)
+  const db = tenantDb(prisma, code)
+  const row = await db.memberUser.findUnique({
+    where: { id },
+    include: getLoad(params),
+  })
+
+  if (!row) {
+    throw notFound('Member-user relation not found')
+  }
+  if (!canReadAll && row.userId !== ctx.userId) {
+    throw forbidden('You can only access your own member-user relations')
+  }
+
+  return (await hydrateMemberUsers(ctx, code, [row], params))[0]
+}
+
+export const patchMemberUser = async (
+  ctx: AuthContext,
+  code: string,
+  id: string,
+  patch: MemberUserSettingsPatch,
+  params: ResourceParams,
+): Promise<MemberUser> => {
+  const current = await getMemberUser(ctx, code, id, { include: [] })
+  const db = tenantDb(prisma, code)
+  const row = await db.memberUser.update({
+    where: { id },
+    data: {
+      settings: mergeMemberUserSettings(current.settings, patch),
+    },
+    include: getLoad(params),
+  })
+
+  return (await hydrateMemberUsers(ctx, code, [row], params))[0]
+}

--- a/social/src/features/member-users/types.ts
+++ b/social/src/features/member-users/types.ts
@@ -1,0 +1,12 @@
+import type { MemberUser as DbMemberUser } from '../../generated/prisma/client'
+import type { SerializableMember } from '../members/types'
+import type { User } from '../users/types'
+import type { MemberUserSettings } from './settings'
+
+export type MemberUser = Omit<DbMemberUser, 'settings'> & {
+  settings: MemberUserSettings
+  member?: SerializableMember
+  user?: User
+}
+
+export type SerializableMemberUser = Omit<MemberUser, 'settings'> & MemberUserSettings

--- a/social/src/features/member-users/types.ts
+++ b/social/src/features/member-users/types.ts
@@ -1,12 +1,16 @@
 import type { MemberUser as DbMemberUser } from '../../generated/prisma/client'
-import type { SerializableMember } from '../members/types'
+import type { Member, SerializableMember } from '../members/types'
 import type { User } from '../users/types'
 import type { MemberUserSettings } from './settings'
 
 export type MemberUser = Omit<DbMemberUser, 'settings'> & {
   settings: MemberUserSettings
-  member?: SerializableMember
+  member?: Member
   user?: User
 }
 
-export type SerializableMemberUser = Omit<MemberUser, 'settings'> & MemberUserSettings
+export type EnrichedMemberUser = Omit<MemberUser, 'member'> & {
+  member?: SerializableMember
+}
+
+export type SerializableMemberUser = Omit<EnrichedMemberUser, 'settings'> & MemberUserSettings

--- a/social/src/features/users/controller.ts
+++ b/social/src/features/users/controller.ts
@@ -4,10 +4,10 @@ import { getCollectionSerializerOptions } from '../../server/jsonapi-serialize'
 import { getCollectionParams, getIdParam, getResourceParams } from '../../server/request'
 import { getValidatedBody } from '../../server/validation'
 import { serializeMembers } from '../members/serialize'
-import type { CreateUserBody, PatchUserSettingsBody } from './schema'
+import type { CreateUserBody, PatchUserBody } from './schema'
 import { unsubscribeQuerySchema } from './schema'
-import { serializeUser, serializeUsers, serializeUserSettings } from './serialize'
-import { createUser, getUserById, listUserMembers, listUsers, patchUserSettings, unsubscribeUser } from './service'
+import { serializeUser, serializeUsers } from './serialize'
+import { createUser, getUserById, listUserMembers, listUsers, patchUser, unsubscribeUser } from './service'
 import { redeemUnsubscribeToken } from '../../clients/auth'
 import { badRequest } from '../../utils/error'
 
@@ -18,7 +18,6 @@ export const getUsersRoute: RequestHandler = async (req, res) => {
   const params = getCollectionParams(req, {
     filter: ['members'],
     sort: ['created'],
-    include: ['settings'],
   })
 
   const result = await listUsers(ctx, params)
@@ -30,14 +29,13 @@ export const getUsersRoute: RequestHandler = async (req, res) => {
 export const postUsers: RequestHandler = async (req, res) => {
   const ctx = getAuthContext(req)
   const body = getValidatedBody<CreateUserBody>(req)
-  const userSettings = body.included?.find((resource) => resource.type === 'user-settings')?.attributes
-  const params = getResourceParams(req, { include: ['settings'] })
+  const params = getResourceParams(req, {})
 
   const user = await createUser({
     id: ctx.userId,
     email: body.data.attributes?.email,
     name: body.data.attributes?.name,
-    settings: userSettings,
+    language: body.data.attributes?.language,
   })
 
   const payload = await serializeUser(user, params)
@@ -46,7 +44,7 @@ export const postUsers: RequestHandler = async (req, res) => {
 
 export const getUsersMe: RequestHandler = async (req, res) => {
   const ctx = getAuthContext(req)
-  const params = getResourceParams(req, { include: ['settings'] })  
+  const params = getResourceParams(req, {})
   
   const user = await getUserById(ctx, ctx.userId)
   const payload = await serializeUser(user, params)
@@ -56,7 +54,7 @@ export const getUsersMe: RequestHandler = async (req, res) => {
 export const getUserByIdRoute: RequestHandler = async (req, res) => {
   const ctx = getAuthContext(req)
   const requestedId = getIdParam(req, 'id')
-  const params = getResourceParams(req, { include: ['settings'] })
+  const params = getResourceParams(req, {})
 
   const user = await getUserById(ctx, requestedId)
   const payload = await serializeUser(user, params)
@@ -80,22 +78,13 @@ export const getUserMembersRoute: RequestHandler = async (req, res) => {
   res.status(200).json(payload)
 }
 
-export const getUserSettingsRoute: RequestHandler = async (req, res) => {
+export const patchUserRoute: RequestHandler = async (req, res) => {
   const ctx = getAuthContext(req)
   const requestedId = getIdParam(req, 'id')
+  const body = getValidatedBody<PatchUserBody>(req)
 
-  const user = await getUserById(ctx, requestedId)
-  const payload = await serializeUserSettings(user)
-  res.status(200).json(payload)
-}
-
-export const patchUserSettingsRoute: RequestHandler = async (req, res) => {
-  const ctx = getAuthContext(req)
-  const requestedId = getIdParam(req, 'id')
-  const body = getValidatedBody<PatchUserSettingsBody>(req)
-
-  const user = await patchUserSettings(ctx, requestedId, body.data.attributes)
-  const payload = await serializeUserSettings(user)
+  const user = await patchUser(ctx, requestedId, body.data.attributes.language)
+  const payload = await serializeUser(user)
   res.status(200).json(payload)
 }
 

--- a/social/src/features/users/controller.ts
+++ b/social/src/features/users/controller.ts
@@ -83,6 +83,10 @@ export const patchUserRoute: RequestHandler = async (req, res) => {
   const requestedId = getIdParam(req, 'id')
   const body = getValidatedBody<PatchUserBody>(req)
 
+  if (body.data.id && body.data.id !== requestedId) {
+    throw badRequest('Resource id does not match route id')
+  }
+
   const user = await patchUser(ctx, requestedId, body.data.attributes.language)
   const payload = await serializeUser(user)
   res.status(200).json(payload)

--- a/social/src/features/users/routes.ts
+++ b/social/src/features/users/routes.ts
@@ -2,14 +2,13 @@ import { Router } from 'express'
 import { userAuth } from '../../server/auth'
 import { Scope } from '../../server/scopes'
 import { validateBody } from '../../server/validation'
-import { createUserBodySchema, patchUserSettingsBodySchema } from './schema'
+import { createUserBodySchema, patchUserBodySchema } from './schema'
 import {
   getUserByIdRoute,
   getUserMembersRoute,
-  getUserSettingsRoute,
   getUsersMe,
   getUsersRoute,
-  patchUserSettingsRoute,
+  patchUserRoute,
   postUsers,
   unsubscribeUserRoute,
 } from './controller'
@@ -21,8 +20,7 @@ router.post('/users/unsubscribe', unsubscribeUserRoute)
 router.get('/users', userAuth(Scope.SocialRead), getUsersRoute)
 router.get('/users/me', userAuth(Scope.SocialRead), getUsersMe)
 router.get('/users/:id/members', userAuth(Scope.SocialRead), getUserMembersRoute)
-router.get('/users/:id/settings', userAuth(Scope.SocialRead), getUserSettingsRoute)
-router.patch('/users/:id/settings', userAuth(Scope.SocialWrite), validateBody(patchUserSettingsBodySchema), patchUserSettingsRoute)
+router.patch('/users/:id', userAuth(Scope.SocialWrite), validateBody(patchUserBodySchema), patchUserRoute)
 router.get('/users/:id', userAuth(Scope.SocialRead), getUserByIdRoute)
 
 export default router

--- a/social/src/features/users/schema.ts
+++ b/social/src/features/users/schema.ts
@@ -1,36 +1,25 @@
 import { z } from 'zod'
 import { jsonApiDocumentSchema, jsonApiResourceSchema } from '../../server/jsonapi-schema'
 
-export const userSettingsAttributesSchema = z.object({
-  language: z.string().optional(),
-  notifications: z.object({
-    myAccount: z.boolean().optional(),
-    group: z.boolean().optional(),
-  }).optional(),
-  emails: z.object({
-    myAccount: z.boolean().optional(),
-    group: z.enum(['never', 'weekly', 'monthly']).optional(),
-  }).optional(),
-}).strict()
-
-export type UserSettings = z.infer<typeof userSettingsAttributesSchema>
-
-const userSettingsSchema = jsonApiResourceSchema('user-settings', userSettingsAttributesSchema)
-
 const userAttributesSchema = z.object({
   email: z.email().optional(),
   name: z.string().trim().min(1).max(255).optional(),
+  language: z.string().trim().min(1).max(31).nullable().optional(),
 }).strict()
 
 export type UserAttributes = z.infer<typeof userAttributesSchema>
 
 const userSchema = jsonApiResourceSchema('users', userAttributesSchema)
 
-export const createUserBodySchema = jsonApiDocumentSchema(userSchema, userSettingsSchema)
-export const patchUserSettingsBodySchema = jsonApiDocumentSchema(userSettingsSchema)
+export const createUserBodySchema = jsonApiDocumentSchema(userSchema)
+export const patchUserBodySchema = jsonApiDocumentSchema(
+  jsonApiResourceSchema('users', z.object({
+    language: z.string().trim().min(1).max(31).nullable(),
+  }).strict()),
+)
 export const unsubscribeQuerySchema = z.object({
   token: z.string().min(1),
 })
 
 export type CreateUserBody = z.infer<typeof createUserBodySchema>
-export type PatchUserSettingsBody = z.infer<typeof patchUserSettingsBodySchema>
+export type PatchUserBody = z.infer<typeof patchUserBodySchema>

--- a/social/src/features/users/serialize.ts
+++ b/social/src/features/users/serialize.ts
@@ -1,34 +1,16 @@
 import TsJapi from 'ts-japi'
 import { config } from '../../config'
 import type { SerializerOptions } from '../../server/jsonapi-serialize'
-import type { User, UserSettings } from './types'
+import type { User } from './types'
 
-const { Linker, Relator, Serializer } = TsJapi
-type UserSettingsWithUserId = UserSettings & { userId: string }
+const { Linker, Serializer } = TsJapi
 
-const UserSettingsSerializer = new Serializer<UserSettingsWithUserId>('user-settings', {
-  version: null,
-  projection: {
-    language: 1,
-    notifications: 1,
-    emails: 1,
-  },
-  linkers: {
-    resource: new Linker((settings) => `${config.API_BASE_URL}/users/${settings.userId}/settings`)
-  },
-  idKey: 'userId',
-})
-
-const UserSettingsRelator = new Relator<User, UserSettingsWithUserId>(async (user) => ({
-  userId: user.id,
-  ...user.settings,
-}), UserSettingsSerializer, { relatedName: 'settings' })
-
-const UserSerializer = new Serializer<User>('users', {
+export const UserSerializer = new Serializer<User>('users', {
   version: null,
   projection: {
     email: 1,
     name: 1,
+    language: 1,
     created: 1,
     updated: 1,
   },
@@ -37,24 +19,10 @@ const UserSerializer = new Serializer<User>('users', {
   }
 })
 
-const withIncludedRelationships = (params?: SerializerOptions<User>): SerializerOptions<User> => ({
-  ...params,
-  relators: Array.isArray(params?.include) && params.include.some((path) => path === 'settings')
-    ? { settings: UserSettingsRelator }
-    : {},
-})
-
-export const serializeUser = async (user: User, params: {include: string[]}) => {
-  return UserSerializer.serialize(user, withIncludedRelationships(params))
+export const serializeUser = async (user: User, params?: SerializerOptions<User>) => {
+  return UserSerializer.serialize(user, params)
 }
 
 export const serializeUsers = async (users: User[], params?: SerializerOptions<User>) => {
-  return UserSerializer.serialize(users, withIncludedRelationships(params))
-}
-
-export const serializeUserSettings = async (user: User) => {
-  return UserSettingsSerializer.serialize({
-    userId: user.id,
-    ...user.settings,
-  })
+  return UserSerializer.serialize(users, params)
 }

--- a/social/src/features/users/service.ts
+++ b/social/src/features/users/service.ts
@@ -122,15 +122,17 @@ export const unsubscribeUser = async (id: string): Promise<void> => {
   const db = privilegedDb(prisma)
 
   try {
-    const relations = await db.memberUser.findMany({ where: { userId: id } })
-    await Promise.all(relations.map((relation) => db.memberUser.update({
-      where: { id: relation.id },
-      data: {
-        settings: mergeMemberUserSettings(relation.settings as MemberUserSettings, {
-          emails: { group: 'never' },
-        }),
-      },
-    })))
+    await db.transaction(async (tx) => {
+      const relations = await tx.memberUser.findMany({ where: { userId: id } })
+      await Promise.all(relations.map((relation) => tx.memberUser.update({
+        where: { id: relation.id },
+        data: {
+          settings: mergeMemberUserSettings(relation.settings as MemberUserSettings, {
+            emails: { group: 'never' },
+          }),
+        },
+      })))
+    })
   } catch (cause) {
     throw internalError(`Failed to unsubscribe user ${id}`, { cause })
   }

--- a/social/src/features/users/service.ts
+++ b/social/src/features/users/service.ts
@@ -1,6 +1,6 @@
 import prisma from '../../utils/prisma'
 import { Prisma, User as DbUser, type Member as DbMember } from '../../generated/prisma/client'
-import type { User, UserSettings, CreateUserInput } from './types'
+import type { User, CreateUserInput } from './types'
 import { badRequest, forbidden, internalError, notFound } from '../../utils/error'
 import { privilegedDb } from '../../server/multitenant'
 import { AuthContext } from '../../server/context'
@@ -10,18 +10,10 @@ import { type DbGroup, getGroupByCode, isGroupAdmin, toGroup } from '../groups/s
 import { enrichMembers, toMember } from '../members/service'
 import type { SerializableMember } from '../members/types'
 import { countUserMembers, findUserMembers } from './member-query'
+import type { MemberUserSettings } from '../member-users/settings'
+import { mergeMemberUserSettings } from '../member-users/settings'
 
-const toUser = (user: DbUser): User => {
-  return {
-    id: user.id,
-    email: user.email,
-    name: user.name,
-    language: user.language,
-    settings: user.settings as UserSettings,
-    created: user.created,
-    updated: user.updated,
-  }
-}
+export const toUser = (user: DbUser): User => user
 
 export const listGroupAdmins = async (
   ctx: AuthContext,
@@ -60,34 +52,11 @@ const canReadUser = (ctx: AuthContext, id: string): boolean => {
   return ctx.userId === id || ctx.isSuperadmin || ctx.canReadAllSocial
 }
 
-const mergeSettings = (current: UserSettings, patch: UserSettings): Prisma.InputJsonObject => {
-  const merged: UserSettings = {
-    ...current,
-    ...patch,
-  }
-
-  if (patch.notifications) {
-    merged.notifications = {
-      ...current.notifications,
-      ...patch.notifications,
-    }
-  }
-
-  if (patch.emails) {
-    merged.emails = {
-      ...current.emails,
-      ...patch.emails,
-    }
-  }
-
-  return merged as Prisma.InputJsonObject
-}
-
 export const createUser = async ({
   id,
   email,
   name,
-  settings,
+  language,
 }: CreateUserInput): Promise<User> => {
   if (!email) {
     throw badRequest('User email is required in attributes')
@@ -101,12 +70,12 @@ export const createUser = async ({
       id,
       email,
       name,
-      settings,
+      language,
     },
     update: {
       email,
       name,
-      settings,
+      language,
     }
   })
 
@@ -126,22 +95,20 @@ export const getUserById = async (ctx: AuthContext, id: string): Promise<User> =
   return toUser(user)
 }
 
-export const patchUserSettings = async (
+export const patchUser = async (
   ctx: AuthContext,
   id: string,
-  settings: UserSettings,
+  language: string | null,
 ): Promise<User> => {
   if (ctx.userId !== id) {
-    throw forbidden('You can only update your own user settings')
+    throw forbidden('You can only update your own user resource')
   }
 
-  const current = await getUserById(ctx, id)
+  await getUserById(ctx, id)
   const db = privilegedDb(prisma)
   const updated = await db.user.update({
     where: { id },
-    data: {
-      settings: mergeSettings(current.settings, settings),
-    },
+    data: { language },
   })
 
   return toUser(updated)
@@ -149,20 +116,17 @@ export const patchUserSettings = async (
 
 export const unsubscribeUser = async (id: string): Promise<void> => {
   const db = privilegedDb(prisma)
-  const user = await db.user.findUnique({ where: { id } })
-  if (!user) {
-    return
-  }
 
   try {
-    await db.user.update({
-      where: { id },
+    const relations = await db.memberUser.findMany({ where: { userId: id } })
+    await Promise.all(relations.map((relation) => db.memberUser.update({
+      where: { id: relation.id },
       data: {
-        settings: mergeSettings(user.settings as UserSettings, {
+        settings: mergeMemberUserSettings(relation.settings as MemberUserSettings, {
           emails: { group: 'never' },
         }),
       },
-    })
+    })))
   } catch (cause) {
     throw internalError(`Failed to unsubscribe user ${id}`, { cause })
   }

--- a/social/src/features/users/service.ts
+++ b/social/src/features/users/service.ts
@@ -114,6 +114,10 @@ export const patchUser = async (
   return toUser(updated)
 }
 
+/**
+ * Updates all related member-users to set the email group 
+ * notifications to "never".
+ */
 export const unsubscribeUser = async (id: string): Promise<void> => {
   const db = privilegedDb(prisma)
 

--- a/social/src/features/users/types.ts
+++ b/social/src/features/users/types.ts
@@ -1,15 +1,10 @@
 import type { User as DbUser } from '../../generated/prisma/client'
-import type { UserSettings, UserAttributes } from './schema'
-
-export type { UserSettings } from './schema'
+import type { UserAttributes } from './schema'
 
 // Input types derived from request schema
 export interface CreateUserInput extends UserAttributes {
   id: string
-  settings?: UserSettings
 }
 
 // Output types derived from Prisma models
-export interface User extends DbUser {
-  settings: UserSettings
-}
+export type User = DbUser

--- a/social/src/server/jsonapi-serialize.ts
+++ b/social/src/server/jsonapi-serialize.ts
@@ -64,7 +64,7 @@ const getPaginationLinks = (url: string, pagination: PaginationOptions, totalCou
   return { first, prev, self, next, last }
 }
 
-export const getResourceLink = (type: "groups" | "members" | "offers" | "needs" | "categories" | "files" | "group-settings", code: string, id: string) => {
+export const getResourceLink = (type: "groups" | "members" | "member-users" | "offers" | "needs" | "categories" | "files" | "group-settings", code: string, id: string) => {
   const tenantBase = new URL(`${config.API_BASE_URL}/${code}`)
   switch (type) {
     case 'groups':
@@ -73,6 +73,8 @@ export const getResourceLink = (type: "groups" | "members" | "offers" | "needs" 
       return `${tenantBase}/settings`
     case 'members':
       return `${tenantBase}/members/${id}`
+    case 'member-users':
+      return `${tenantBase}/member-users/${id}`
     case 'offers':
     case 'needs':
       return `${tenantBase}/posts/${id}`

--- a/social/src/server/multitenant.ts
+++ b/social/src/server/multitenant.ts
@@ -3,6 +3,10 @@ import { Prisma, type PrismaClient } from '../generated/prisma/client'
 export type PrivilegedDbClient = ReturnType<typeof privilegedDb>
 export type TenantDbClient = ReturnType<typeof tenantDb>
 export type DbClient = PrivilegedDbClient | TenantDbClient
+type RlsClient = {
+  $executeRaw: PrismaClient['$executeRaw']
+  $transaction: (...args: any[]) => Promise<any>
+}
 
 export function privilegedDb(prisma: PrismaClient) {
   return prisma.$extends(bypassRLS())
@@ -11,6 +15,22 @@ export function privilegedDb(prisma: PrismaClient) {
 export function tenantDb(prisma: PrismaClient, tenantId: string) {
   return prisma.$extends(forTenant(tenantId))
 }
+
+const transactionWithRls = (
+  prisma: RlsClient,
+  rlsQuery: Prisma.Sql,
+) => ((...args: Parameters<PrismaClient['$transaction']>) => {
+  const [arg, options] = args as [any, any]
+
+  if (Array.isArray(arg)) {
+    return prisma.$transaction([prisma.$executeRaw(rlsQuery), ...arg], options)
+  }
+
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+    await tx.$executeRaw(rlsQuery)
+    return arg(tx)
+  }, options)
+}) as PrismaClient['$transaction']
 
 function bypassRLS() {
   return Prisma.defineExtension((prisma) =>
@@ -23,6 +43,12 @@ function bypassRLS() {
           ])
           return result
         }
+      },
+      client: {
+        transaction: transactionWithRls(
+          prisma,
+          Prisma.sql`SELECT set_config('app.bypass_rls', 'on', TRUE)`,
+        ),
       },
     })
   )
@@ -42,19 +68,10 @@ function forTenant(tenantId: string) {
       },
       client: {
         tenantId,
-        transaction: ((...args: Parameters<PrismaClient['$transaction']>) => {
-          const rlsQuery = Prisma.sql`SELECT set_config('app.current_tenant_id', ${tenantId}, TRUE)`
-          const [arg, options] = args as [any, any]
-
-          if (Array.isArray(arg)) {
-            return prisma.$transaction([prisma.$executeRaw(rlsQuery), ...arg], options)
-          }
-
-          return prisma.$transaction(async (tx) => {
-            await tx.$executeRaw(rlsQuery)
-            return arg(tx)
-          }, options)
-        }) as PrismaClient['$transaction'],
+        transaction: transactionWithRls(
+          prisma,
+          Prisma.sql`SELECT set_config('app.current_tenant_id', ${tenantId}, TRUE)`,
+        ),
       }
     })
   )

--- a/social/src/server/request.ts
+++ b/social/src/server/request.ts
@@ -61,6 +61,23 @@ export const hasInclude = (params: ResourceParams, path: string) => {
   return params.include.some((item) => item === path || item.startsWith(`${path}.`))
 }
 
+/** Returns the named filter values, parsing each value with the schema when provided. */
+export function getFilter(params: CollectionParams, name: string): string[] | undefined
+export function getFilter<T>(params: CollectionParams, name: string, schema: z.ZodType<T>): T[] | undefined
+export function getFilter<T>(params: CollectionParams, name: string, schema?: z.ZodType<T>) {
+  const values = params.filters[name]
+  if (!values || !schema) {
+    return values
+  }
+
+  const result = z.array(schema).safeParse(values)
+  if (!result.success) {
+    throw badRequest(`Invalid ${name} filter`, { details: result.error.issues })
+  }
+
+  return result.data
+}
+
 // qs splits commas before URL decoding, so URLSearchParams values need normalization after parsing.
 const splitCommaSeparated = (value: unknown) => typeof value === 'string' ? value.split(',') : value
 

--- a/social/test/group.test.ts
+++ b/social/test/group.test.ts
@@ -582,7 +582,7 @@ describe('Groups endpoints', () => {
     assert.strictEqual(admins.body.meta.count, 2)
     const adminResource = admins.body.data.find((resource: any) => resource.id === admin.id)
     assert.strictEqual(typeof adminResource.attributes.email, 'string')
-    assert.strictEqual(adminResource.relationships.settings, undefined)
+    assert.strictEqual(adminResource.relationships, undefined)
   })
 
   test('group members relationship is only exposed to viewers who can list members', async () => {

--- a/social/test/member-user.test.ts
+++ b/social/test/member-user.test.ts
@@ -1,0 +1,364 @@
+import assert from 'node:assert'
+import { after, before, beforeEach, describe, test } from 'node:test'
+import request from 'supertest'
+import { Scope } from '../src/server/context'
+import { tenantDb } from '../src/server/multitenant'
+import prisma from '../src/utils/prisma'
+import { auth, serviceAuth } from './mocks/auth'
+import { resetDb, seedGroup, seedGroupAdmin, seedMember, seedMemberUser } from './mocks/seed'
+import { setupTestServer, teardownTestServer } from './mocks/server'
+import { includedResource, toUuid } from './mocks/utils'
+
+let app: any
+
+before(async () => {
+  const server = await setupTestServer()
+  app = server.app
+})
+
+after(async () => {
+  await teardownTestServer()
+})
+
+describe('Member-user endpoints', () => {
+  beforeEach(async () => {
+    await resetDb()
+  })
+
+  test('member-user endpoints require JWT', async () => {
+    const id = toUuid('member-user-no-auth')
+
+    await request(app)
+      .get('/member-user-auth/member-users')
+      .expect(401)
+
+    await request(app)
+      .get(`/member-user-auth/member-users/${id}`)
+      .expect(401)
+
+    await request(app)
+      .patch(`/member-user-auth/member-users/${id}`)
+      .send({
+        data: {
+          type: 'member-users',
+          attributes: {},
+        },
+      })
+      .expect(401)
+  })
+
+  test('owners can list and read only their own relations', async () => {
+    const owner = await auth('member-user-owner')
+    const other = await auth('member-user-other')
+    await seedGroup({ tenantId: 'member-user-owner-group' })
+    const member = await seedMember({
+      tenantId: 'member-user-owner-group',
+      userId: owner.id,
+    })
+    await seedMember({
+      tenantId: 'member-user-owner-group',
+      userId: other.id,
+    })
+    const relation = await tenantDb(prisma, 'member-user-owner-group').memberUser.findFirstOrThrow({
+      where: { memberId: member.id, userId: owner.id },
+    })
+
+    const collection = await request(app)
+      .get('/member-user-owner-group/member-users')
+      .set('Authorization', `Bearer ${owner.token}`)
+      .expect(200)
+
+    assert.strictEqual(collection.body.meta.count, 1)
+    assert.strictEqual(collection.body.data.length, 1)
+    assert.strictEqual(collection.body.data[0].id, relation.id)
+    assert.deepStrictEqual(collection.body.data[0].attributes, {
+      notifications: {
+        myAccount: true,
+        group: true,
+      },
+      emails: {
+        myAccount: true,
+        group: 'monthly',
+      },
+    })
+    assert.deepStrictEqual(collection.body.data[0].relationships.user.data, {
+      type: 'users',
+      id: owner.id,
+    })
+    assert.deepStrictEqual(collection.body.data[0].relationships.member.data, {
+      type: 'members',
+      id: member.id,
+    })
+
+    const detail = await request(app)
+      .get(`/member-user-owner-group/member-users/${relation.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .expect(200)
+
+    assert.strictEqual(detail.body.data.id, relation.id)
+
+    const otherRelation = await tenantDb(prisma, 'member-user-owner-group').memberUser.findFirstOrThrow({
+      where: { userId: other.id },
+    })
+    await request(app)
+      .get(`/member-user-owner-group/member-users/${otherRelation.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .expect(403)
+
+    await request(app)
+      .get(`/member-user-owner-group/member-users?filter[user]=${other.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .expect(403)
+  })
+
+  test('collection supports comma-separated filters, includes, and pagination', async () => {
+    const firstUser = await auth('member-user-filter-first')
+    const secondUser = await auth('member-user-filter-second')
+    await seedGroup({ tenantId: 'member-user-filter-group' })
+    const firstMember = await seedMember({
+      tenantId: 'member-user-filter-group',
+      userId: firstUser.id,
+    })
+    const secondMember = await seedMember({
+      tenantId: 'member-user-filter-group',
+      userId: secondUser.id,
+    })
+    await seedMember({ tenantId: 'member-user-filter-group' })
+    const service = await serviceAuth()
+
+    const response = await request(app)
+      .get(`/member-user-filter-group/member-users?filter[user]=${firstUser.id},${secondUser.id}&filter[member]=${firstMember.id},${secondMember.id}&include=user,member&page[size]=1`)
+      .set('Authorization', `Bearer ${service.token}`)
+      .expect(200)
+
+    assert.strictEqual(response.body.meta.count, 2)
+    assert.strictEqual(response.body.data.length, 1)
+    assert.strictEqual(typeof response.body.links.next, 'string')
+    const resource = response.body.data[0]
+    assert.ok(includedResource(response.body, 'users', resource.relationships.user.data.id))
+    assert.ok(includedResource(response.body, 'members', resource.relationships.member.data.id))
+
+    await request(app)
+      .get('/member-user-filter-group/member-users?filter[user]=not-a-uuid')
+      .set('Authorization', `Bearer ${service.token}`)
+      .expect(400)
+  })
+
+  test('owners can patch settings with a nested merge', async () => {
+    const owner = await auth('member-user-patch-owner')
+    await seedGroup({ tenantId: 'member-user-patch-group' })
+    const member = await seedMember({
+      tenantId: 'member-user-patch-group',
+      userId: owner.id,
+    })
+    const relation = await tenantDb(prisma, 'member-user-patch-group').memberUser.findFirstOrThrow({
+      where: { memberId: member.id, userId: owner.id },
+    })
+
+    const response = await request(app)
+      .patch(`/member-user-patch-group/member-users/${relation.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({
+        data: {
+          type: 'member-users',
+          id: relation.id,
+          attributes: {
+            notifications: {
+              group: false,
+            },
+            emails: {
+              myAccount: false,
+            },
+          },
+        },
+      })
+      .expect(200)
+
+    assert.deepStrictEqual(response.body.data.attributes, {
+      notifications: {
+        myAccount: true,
+        group: false,
+      },
+      emails: {
+        myAccount: false,
+        group: 'monthly',
+      },
+    })
+
+    const stored = await tenantDb(prisma, 'member-user-patch-group').memberUser.findUniqueOrThrow({
+      where: { id: relation.id },
+    })
+    assert.deepStrictEqual(stored.settings, response.body.data.attributes)
+  })
+
+  test('PATCH rejects immutable relationships, unknown attributes, and mismatched ids', async () => {
+    const owner = await auth('member-user-immutable-owner')
+    await seedGroup({ tenantId: 'member-user-immutable-group' })
+    const member = await seedMember({
+      tenantId: 'member-user-immutable-group',
+      userId: owner.id,
+    })
+    const relation = await tenantDb(prisma, 'member-user-immutable-group').memberUser.findFirstOrThrow({
+      where: { memberId: member.id, userId: owner.id },
+    })
+    const path = `/member-user-immutable-group/member-users/${relation.id}`
+
+    await request(app)
+      .patch(path)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({
+        data: {
+          type: 'member-users',
+          attributes: {},
+          relationships: {
+            user: {
+              data: { type: 'users', id: owner.id },
+            },
+          },
+        },
+      })
+      .expect(400)
+
+    await request(app)
+      .patch(path)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({
+        data: {
+          type: 'member-users',
+          attributes: {
+            role: 'admin',
+          },
+        },
+      })
+      .expect(400)
+
+    await request(app)
+      .patch(path)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({
+        data: {
+          type: 'member-users',
+          id: toUuid('different-member-user-id'),
+          attributes: {},
+        },
+      })
+      .expect(400)
+  })
+
+  test('group admins can read and patch all relations in their group', async () => {
+    const owner = await auth('member-user-admin-target')
+    const admin = await auth('member-user-group-admin')
+    await seedGroup({ tenantId: 'member-user-admin-group' })
+    await seedGroupAdmin({
+      tenantId: 'member-user-admin-group',
+      userId: admin.id,
+    })
+    const member = await seedMember({
+      tenantId: 'member-user-admin-group',
+      userId: owner.id,
+    })
+    const relation = await tenantDb(prisma, 'member-user-admin-group').memberUser.findFirstOrThrow({
+      where: { memberId: member.id, userId: owner.id },
+    })
+
+    const collection = await request(app)
+      .get('/member-user-admin-group/member-users')
+      .set('Authorization', `Bearer ${admin.token}`)
+      .expect(200)
+
+    assert.strictEqual(collection.body.meta.count, 1)
+
+    const response = await request(app)
+      .patch(`/member-user-admin-group/member-users/${relation.id}`)
+      .set('Authorization', `Bearer ${admin.token}`)
+      .send({
+        data: {
+          type: 'member-users',
+          attributes: {
+            emails: {
+              group: 'weekly',
+            },
+          },
+        },
+      })
+      .expect(200)
+
+    assert.strictEqual(response.body.data.attributes.emails.group, 'weekly')
+  })
+
+  test('superadmins and services can read all relations without crossing tenants', async () => {
+    const owner = await auth('member-user-privileged-owner')
+    await seedGroup({ tenantId: 'member-user-first-tenant' })
+    await seedGroup({ tenantId: 'member-user-second-tenant' })
+    const firstMember = await seedMember({
+      tenantId: 'member-user-first-tenant',
+      userId: owner.id,
+    })
+    await seedMember({
+      tenantId: 'member-user-second-tenant',
+      userId: owner.id,
+    })
+    const firstRelation = await tenantDb(prisma, 'member-user-first-tenant').memberUser.findFirstOrThrow({
+      where: { memberId: firstMember.id, userId: owner.id },
+    })
+    const superadmin = await auth('member-user-superadmin', undefined, Scope.Superadmin)
+    const service = await serviceAuth()
+
+    for (const token of [superadmin.token, service.token]) {
+      const response = await request(app)
+        .get(`/member-user-first-tenant/member-users?filter[user]=${owner.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200)
+
+      assert.strictEqual(response.body.meta.count, 1)
+
+      await request(app)
+        .get(`/member-user-second-tenant/member-users/${firstRelation.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404)
+    }
+  })
+
+  test('outsiders cannot access a group member-user collection', async () => {
+    const owner = await auth('member-user-outsider-owner')
+    const outsider = await auth('member-user-outsider')
+    await seedGroup({ tenantId: 'member-user-outsider-group' })
+    await seedMember({
+      tenantId: 'member-user-outsider-group',
+      userId: owner.id,
+    })
+
+    await request(app)
+      .get('/member-user-outsider-group/member-users')
+      .set('Authorization', `Bearer ${outsider.token}`)
+      .expect(403)
+  })
+
+  test('member-user relations cannot be created or deleted through the API', async () => {
+    const owner = await auth('member-user-read-only-resource')
+    await seedGroup({ tenantId: 'member-user-read-only-group' })
+    const member = await seedMember({
+      tenantId: 'member-user-read-only-group',
+      userId: owner.id,
+    })
+    const relation = await tenantDb(prisma, 'member-user-read-only-group').memberUser.findFirstOrThrow({
+      where: { memberId: member.id, userId: owner.id },
+    })
+
+    await request(app)
+      .post('/member-user-read-only-group/member-users')
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({
+        data: {
+          type: 'member-users',
+          attributes: {},
+        },
+      })
+      .expect(404)
+
+    await request(app)
+      .delete(`/member-user-read-only-group/member-users/${relation.id}`)
+      .set('Authorization', `Bearer ${owner.token}`)
+      .expect(404)
+  })
+})

--- a/social/test/mocks/seed.ts
+++ b/social/test/mocks/seed.ts
@@ -133,7 +133,7 @@ export const seedUser = async (data: Partial<User> = {}): Promise<User> => {
   const input = {
     email: data.email ?? defaults.email,
     name: data.name,
-    settings: toNullableJsonInput(data.settings), 
+    language: data.language,
   }
   
   return db().user.upsert({

--- a/social/test/unit/request.test.ts
+++ b/social/test/unit/request.test.ts
@@ -2,7 +2,8 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import qs from 'qs'
 import type { Request } from 'express'
-import { getCode, getCollectionParams, getIdParam, getResourceParams } from '../../src/server/request'
+import { z } from 'zod'
+import { getCode, getCollectionParams, getFilter, getIdParam, getResourceParams } from '../../src/server/request'
 
 const createRequest = (query: string, params: Record<string, string> = {}): Request => ({
 	query: qs.parse(query, { comma: true }),
@@ -77,6 +78,32 @@ test('getCollectionParams supports comma separated filter values', () => {
 	assert.deepStrictEqual(params.filters, {
 		code: ['code-one', 'code-two'],
 	})
+})
+
+test('getFilter optionally parses filter values with a schema', () => {
+	const params = getCollectionParams(
+		createRequest('filter[score]=1,2&filter[name]=Alice'),
+		{
+			filter: ['score', 'name'],
+			sort: ['created'],
+		},
+	)
+
+	assert.deepStrictEqual(getFilter(params, 'name'), ['Alice'])
+	assert.deepStrictEqual(getFilter(params, 'score', z.coerce.number().int()), [1, 2])
+	assert.strictEqual(getFilter(params, 'missing'), undefined)
+})
+
+test('getFilter rejects filter values that do not match its schema', () => {
+	const params = getCollectionParams(
+		createRequest('filter[id]=not-a-uuid'),
+		{ filter: ['id'], sort: ['created'] },
+	)
+
+	assert.throws(
+		() => getFilter(params, 'id', z.uuid()),
+		/Invalid id filter/,
+	)
 })
 
 test('getCollectionParams parses allowlisted comparisons alongside equality filters', () => {

--- a/social/test/user.test.ts
+++ b/social/test/user.test.ts
@@ -537,6 +537,23 @@ describe('Users endpoints', () => {
       .send(payload)
       .expect(403)
 
+    await request(app)
+      .patch(`/users/${subject}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        data: {
+          ...payload.data,
+          id: other,
+        },
+      })
+      .expect(400)
+
+    const unchanged = await request(app)
+      .get(`/users/${subject}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    assert.strictEqual(unchanged.body.data.attributes.language, 'en')
+
     const res = await request(app)
       .patch(`/users/${subject}`)
       .set('Authorization', `Bearer ${token}`)
@@ -641,6 +658,70 @@ describe('Users endpoints', () => {
       .set('Authorization', `Bearer ${userToken}`)
       .expect(200)
     assert.strictEqual(user.body.data.attributes.language, 'ca')
+  })
+
+  test('POST /users/unsubscribe rolls back every relation when one update fails', async () => {
+    const userId = toUuid('unsubscribe-atomic-user')
+    const token = 'atomic-unsubscribe-token'
+    await seedUser({ id: userId, email: 'unsubscribe-atomic@example.org' })
+    await seedGroup({ tenantId: 'unsubscribe-atomic-one', status: 'active' })
+    await seedGroup({ tenantId: 'unsubscribe-atomic-two', status: 'active' })
+    const firstMember = await seedMember({ tenantId: 'unsubscribe-atomic-one' })
+    const secondMember = await seedMember({ tenantId: 'unsubscribe-atomic-two' })
+    const first = await seedMemberUser({
+      tenantId: 'unsubscribe-atomic-one',
+      memberId: firstMember.id,
+      userId,
+      settings: {
+        notifications: { myAccount: true, group: true },
+        emails: { myAccount: true, group: 'weekly' },
+      },
+    })
+    const second = await seedMemberUser({
+      tenantId: 'unsubscribe-atomic-two',
+      memberId: secondMember.id,
+      userId,
+      settings: {
+        notifications: { myAccount: true, group: true },
+        emails: { myAccount: true, group: 'monthly' },
+      },
+    })
+    seedAuthUnsubscribeToken(token, userId, 'unsubscribe-atomic@example.org')
+
+    await prisma.$executeRawUnsafe(`
+      CREATE FUNCTION test_fail_second_unsubscribe_update() RETURNS trigger AS $$
+      BEGIN
+        IF current_setting('test.unsubscribe_update_seen', TRUE) = 'yes' THEN
+          RAISE EXCEPTION 'forced second unsubscribe update failure';
+        END IF;
+        PERFORM set_config('test.unsubscribe_update_seen', 'yes', TRUE);
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `)
+    await prisma.$executeRawUnsafe(`
+      CREATE TRIGGER test_fail_second_unsubscribe_update
+      BEFORE UPDATE OF settings ON "MemberUser"
+      FOR EACH ROW EXECUTE FUNCTION test_fail_second_unsubscribe_update();
+    `)
+
+    try {
+      await request(app)
+        .post(`/users/unsubscribe?token=${token}`)
+        .expect(500)
+    } finally {
+      await prisma.$executeRawUnsafe(
+        'DROP TRIGGER test_fail_second_unsubscribe_update ON "MemberUser"',
+      )
+      await prisma.$executeRawUnsafe('DROP FUNCTION test_fail_second_unsubscribe_update()')
+    }
+
+    assert.deepStrictEqual((await tenantDb(prisma, 'unsubscribe-atomic-one').memberUser.findUniqueOrThrow({
+      where: { id: first.id },
+    })).settings, first.settings)
+    assert.deepStrictEqual((await tenantDb(prisma, 'unsubscribe-atomic-two').memberUser.findUniqueOrThrow({
+      where: { id: second.id },
+    })).settings, second.settings)
   })
 
   test('POST /users/unsubscribe does not disclose a missing social projection', async () => {

--- a/social/test/user.test.ts
+++ b/social/test/user.test.ts
@@ -9,6 +9,8 @@ import { setupTestServer, teardownTestServer } from './mocks/server'
 import { includedResource, toUuid } from './mocks/utils'
 import { resetDb, seedGroup, seedMember, seedMemberUser, seedPost, seedUser } from './mocks/seed'
 import { seedAuthUnsubscribeToken } from './mocks/handlers'
+import { tenantDb } from '../src/server/multitenant'
+import prisma from '../src/utils/prisma'
 
 let app: any
 
@@ -114,12 +116,12 @@ describe('Users endpoints', () => {
       .expect(403)
   })
 
-  test('POST /users creates authenticated user with optional settings include', async () => {
+  test('POST /users creates authenticated user with language', async () => {
     const subject = toUuid('1')
     const token = await signJwt(subject, 'first@example.org')
 
     const res = await request(app)
-      .post('/users?include=settings')
+      .post('/users')
       .set('Authorization', `Bearer ${token}`)
       .send({
         data: {
@@ -127,16 +129,9 @@ describe('Users endpoints', () => {
           attributes: {
             name: 'Alice',
             email: 'alice@example.org',
+            language: 'en',
           }
         },
-        included: [{
-          type: 'user-settings',
-          attributes: {
-            language: 'en',
-            notifications: { myAccount: true, group: false },
-            emails: { myAccount: true, group: 'weekly' },
-          }
-        }]
       })
       .expect(200)
 
@@ -144,9 +139,7 @@ describe('Users endpoints', () => {
     assert.strictEqual(res.body.data.id, subject)
     assert.strictEqual(res.body.data.attributes.email, 'alice@example.org')
     assert.strictEqual(res.body.data.attributes.name, 'Alice')
-    assert.ok(Array.isArray(res.body.included))
-    assert.strictEqual(res.body.included[0].type, 'user-settings')
-    assert.strictEqual(res.body.included[0].attributes.language, 'en')
+    assert.strictEqual(res.body.data.attributes.language, 'en')
   })
 
   test('POST /users rejects credential fields', async () => {
@@ -168,7 +161,7 @@ describe('Users endpoints', () => {
       .expect(400)
   })
 
-  test('POST /users creates default settings returned by GET /users/me?include=settings', async () => {
+  test('POST /users rejects user-settings includes', async () => {
     const subject = toUuid('3')
     const token = await signJwt(subject, 'third@example.org')
 
@@ -186,41 +179,38 @@ describe('Users endpoints', () => {
       })
       .expect(200)
 
-    const res = await request(app)
-      .get('/users/me?include=settings')
+    await request(app)
+      .post('/users?include=settings')
       .set('Authorization', `Bearer ${token}`)
-      .expect(200)
-
-    assert.strictEqual(res.body.data.id, subject)
-    assert.strictEqual(res.body.data.attributes.email, 'third@example.org')
-    assert.deepStrictEqual(res.body.data.relationships.settings.data, {
-      type: 'user-settings',
-      id: subject,
-    })
-    assert.deepStrictEqual(includedResource(res.body, 'user-settings', subject)?.attributes, {})
+      .send({
+        data: {
+          type: 'users',
+          attributes: { email: 'third@example.org' },
+        },
+        included: [{ type: 'user-settings', attributes: {} }],
+      })
+      .expect(400)
   })
 
-  test('GET /users/me supports settings include but rejects members include', async () => {
+  test('GET /users/me returns language and rejects includes', async () => {
     const subject = toUuid('me-include-settings')
     const token = await signJwt(subject, 'me-include-settings@example.org')
 
     await seedUser({
       id: subject,
       email: 'me-include-settings@example.org',
-      settings: {
-        language: 'ca',
-      },
+      language: 'ca',
     })
 
     const res = await request(app)
-      .get('/users/me?include=settings')
+      .get('/users/me')
       .set('Authorization', `Bearer ${token}`)
       .expect(200)
 
-    assert.ok(includedResource(res.body, 'user-settings', subject))
+    assert.strictEqual(res.body.data.attributes.language, 'ca')
 
     await request(app)
-      .get('/users/me?include=members')
+      .get('/users/me?include=settings')
       .set('Authorization', `Bearer ${token}`)
       .expect(400)
   })
@@ -275,7 +265,7 @@ describe('Users endpoints', () => {
     assert.strictEqual(res.body.data.attributes.name, 'Self User')
   })
 
-  test('GET /users allows service read access with filter[members] and include=settings', async () => {
+  test('GET /users allows service read access with filter[members]', async () => {
     const tenantId = 'users-filter-members'
     await seedGroup({ tenantId, status: 'active', access: 'public' })
 
@@ -290,12 +280,13 @@ describe('Users endpoints', () => {
       id: 'linked-user',
       email: 'linked@example.org',
       name: 'Linked User',
+      language: 'it',
     })
 
     const { token: serviceToken } = await serviceAuth()
 
     const res = await request(app)
-      .get(`/users?filter[members]=${member.id}&include=settings`)
+      .get(`/users?filter[members]=${member.id}`)
       .set('Authorization', `Bearer ${serviceToken}`)
       .expect(200)
 
@@ -304,15 +295,7 @@ describe('Users endpoints', () => {
     const linkedUserResource = res.body.data.find((resource: any) => resource.id === linkedUser.id)
     assert.strictEqual(linkedUserResource.type, 'users')
     assert.strictEqual(linkedUserResource.attributes.email, 'linked@example.org')
-    assert.deepStrictEqual(linkedUserResource.relationships.settings.data, {
-      type: 'user-settings',
-      id: linkedUser.id,
-    })
-
-    assert.strictEqual(Array.isArray(res.body.included), true)
-    const linkedSettings = res.body.included.find((resource: any) => resource.type === 'user-settings' && resource.id === linkedUser.id)
-    assert.ok(linkedSettings)
-    assert.deepStrictEqual(linkedSettings.attributes, {})
+    assert.strictEqual(linkedUserResource.attributes.language, 'it')
   })
 
   test('GET /users paginates unique users when one user belongs to multiple filtered members', async () => {
@@ -529,145 +512,97 @@ describe('Users endpoints', () => {
     assert.strictEqual(superadminRes.body.data[0].id, member.id)
   })
 
-  test('GET /users/:id/settings enforces read permissions', async () => {
-    const subject = toUuid('settings-owner')
-    const token = await signJwt(subject, 'settings-owner@example.org')
-    const outsiderToken = await signJwt(toUuid('settings-outsider'), 'settings-outsider@example.org')
-    const { token: serviceToken } = await serviceAuth()
-    const superadminToken = await signJwt(toUuid('settings-superadmin'), 'settings-superadmin@example.org', Scope.Superadmin)
+  test('PATCH /users/:id updates only the caller language', async () => {
+    const subject = toUuid('language-patch-owner')
+    const other = toUuid('language-patch-other')
+    const token = await signJwt(subject, 'language-patch-owner@example.org')
 
     await seedUser({
       id: subject,
-      email: 'settings-owner@example.org',
-      settings: {
-        language: 'es',
-      },
+      email: 'language-patch-owner@example.org',
+      language: 'en',
     })
+    await seedUser({ id: other, email: 'language-patch-other@example.org' })
 
-    const selfRes = await request(app)
-      .get(`/users/${subject}/settings`)
+    const payload = {
+      data: {
+        type: 'users',
+        attributes: { language: 'ca' },
+      },
+    }
+
+    await request(app)
+      .patch(`/users/${other}`)
       .set('Authorization', `Bearer ${token}`)
-      .expect(200)
-
-    assert.strictEqual(selfRes.body.data.type, 'user-settings')
-    assert.strictEqual(selfRes.body.data.id, subject)
-    assert.strictEqual(selfRes.body.data.attributes.language, 'es')
-
-    await request(app)
-      .get(`/users/${subject}/settings`)
-      .set('Authorization', `Bearer ${serviceToken}`)
-      .expect(200)
-
-    await request(app)
-      .get(`/users/${subject}/settings`)
-      .set('Authorization', `Bearer ${superadminToken}`)
-      .expect(200)
-
-    await request(app)
-      .get(`/users/${subject}/settings`)
-      .set('Authorization', `Bearer ${outsiderToken}`)
-      .expect(403)
-  })
-
-  test('PATCH /users/:id/settings is self-only and deep-merges nested settings', async () => {
-    const subject = toUuid('settings-patch-owner')
-    const token = await signJwt(subject, 'settings-patch-owner@example.org')
-    const { token: serviceToken } = await serviceAuth()
-
-    await seedUser({
-      id: subject,
-      email: 'settings-patch-owner@example.org',
-      settings: {
-        language: 'en',
-        notifications: {
-          myAccount: true,
-          group: false,
-        },
-        emails: {
-          myAccount: true,
-          group: 'weekly',
-        },
-      },
-    })
-
-    await request(app)
-      .patch(`/users/${subject}/settings`)
-      .set('Authorization', `Bearer ${serviceToken}`)
-      .send({
-        data: {
-          type: 'user-settings',
-          attributes: {
-            language: 'ca',
-          },
-        },
-      })
+      .send(payload)
       .expect(403)
 
     const res = await request(app)
-      .patch(`/users/${subject}/settings`)
+      .patch(`/users/${subject}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send(payload)
+      .expect(200)
+
+    assert.strictEqual(res.body.data.type, 'users')
+    assert.strictEqual(res.body.data.attributes.language, 'ca')
+  })
+
+  test('PATCH /users/:id rejects preference attributes and old settings routes are gone', async () => {
+    const subject = toUuid('language-patch-validation')
+    const token = await signJwt(subject, 'language-patch-validation@example.org')
+    await seedUser({ id: subject, email: 'language-patch-validation@example.org' })
+
+    await request(app)
+      .patch(`/users/${subject}`)
       .set('Authorization', `Bearer ${token}`)
       .send({
         data: {
-          type: 'user-settings',
-          attributes: {
-            notifications: {
-              group: true,
-            },
-            emails: {
-              group: 'monthly',
-            },
-          },
+          type: 'users',
+          attributes: { notifications: { group: false } },
         },
       })
-      .expect(200)
+      .expect(400)
 
-    assert.strictEqual(res.body.data.id, subject)
-    assert.strictEqual(res.body.data.attributes.language, 'en')
-    assert.deepStrictEqual(res.body.data.attributes.notifications, {
-      myAccount: true,
-      group: true,
-    })
-    assert.deepStrictEqual(res.body.data.attributes.emails, {
-      myAccount: true,
-      group: 'monthly',
-    })
-  })
-
-  test('PATCH /users/:id/settings validates request body', async () => {
-    const subject = toUuid('settings-patch-validation')
-    const token = await signJwt(subject, 'settings-patch-validation@example.org')
-
-    await seedUser({
-      id: subject,
-      email: 'settings-patch-validation@example.org',
-    })
+    await request(app)
+      .get(`/users/${subject}/settings`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(404)
 
     await request(app)
       .patch(`/users/${subject}/settings`)
       .set('Authorization', `Bearer ${token}`)
-      .send({
-        data: {
-          type: 'user-settings',
-          attributes: {
-            emails: {
-              group: 'daily',
-            },
-          },
-        },
-      })
-      .expect(400)
+      .send({ data: { type: 'user-settings', attributes: {} } })
+      .expect(404)
   })
 
-  test('POST /users/unsubscribe redeems a public token and preserves other settings', async () => {
+  test('POST /users/unsubscribe disables newsletters across every tenant relation', async () => {
     const userId = toUuid('unsubscribe-user')
     const token = 'valid-unsubscribe-token'
     await seedUser({
       id: userId,
       email: 'unsubscribe-user@example.org',
+      language: 'ca',
+    })
+    await seedGroup({ tenantId: 'unsubscribe-one', status: 'active' })
+    await seedGroup({ tenantId: 'unsubscribe-two', status: 'active' })
+    const firstMember = await seedMember({ tenantId: 'unsubscribe-one' })
+    const secondMember = await seedMember({ tenantId: 'unsubscribe-two' })
+    const first = await seedMemberUser({
+      tenantId: 'unsubscribe-one',
+      memberId: firstMember.id,
+      userId,
       settings: {
-        language: 'ca',
-        notifications: { myAccount: true, group: true },
-        emails: { myAccount: true, group: 'weekly' },
+        notifications: { myAccount: false, group: true },
+        emails: { myAccount: false, group: 'weekly' },
+      },
+    })
+    const second = await seedMemberUser({
+      tenantId: 'unsubscribe-two',
+      memberId: secondMember.id,
+      userId,
+      settings: {
+        notifications: { myAccount: true, group: false },
+        emails: { myAccount: true, group: 'monthly' },
       },
     })
     seedAuthUnsubscribeToken(token, userId, 'unsubscribe-user@example.org')
@@ -676,15 +611,16 @@ describe('Users endpoints', () => {
       .post(`/users/unsubscribe?token=${token}`)
       .expect(204)
 
-    const userToken = await signJwt(userId, 'unsubscribe-user@example.org')
-    const settings = await request(app)
-      .get(`/users/${userId}/settings`)
-      .set('Authorization', `Bearer ${userToken}`)
-      .expect(200)
-
-    assert.deepStrictEqual(settings.body.data.attributes, {
-      language: 'ca',
-      notifications: { myAccount: true, group: true },
+    assert.deepStrictEqual((await tenantDb(prisma, 'unsubscribe-one').memberUser.findUniqueOrThrow({
+      where: { id: first.id },
+    })).settings, {
+      notifications: { myAccount: false, group: true },
+      emails: { myAccount: false, group: 'never' },
+    })
+    assert.deepStrictEqual((await tenantDb(prisma, 'unsubscribe-two').memberUser.findUniqueOrThrow({
+      where: { id: second.id },
+    })).settings, {
+      notifications: { myAccount: true, group: false },
       emails: { myAccount: true, group: 'never' },
     })
 
@@ -692,16 +628,19 @@ describe('Users endpoints', () => {
       .post(`/users/unsubscribe?token=${token}`)
       .expect(204)
 
-    const repeatedSettings = await request(app)
-      .get(`/users/${userId}/settings`)
+    assert.deepStrictEqual((await tenantDb(prisma, 'unsubscribe-one').memberUser.findUniqueOrThrow({
+      where: { id: first.id },
+    })).settings, {
+      notifications: { myAccount: false, group: true },
+      emails: { myAccount: false, group: 'never' },
+    })
+
+    const userToken = await signJwt(userId, 'unsubscribe-user@example.org')
+    const user = await request(app)
+      .get(`/users/${userId}`)
       .set('Authorization', `Bearer ${userToken}`)
       .expect(200)
-
-    assert.deepStrictEqual(repeatedSettings.body.data.attributes, {
-      language: 'ca',
-      notifications: { myAccount: true, group: true },
-      emails: { myAccount: true, group: 'never' },
-    })
+    assert.strictEqual(user.body.data.attributes.language, 'ca')
   })
 
   test('POST /users/unsubscribe does not disclose a missing social projection', async () => {
@@ -719,8 +658,16 @@ describe('Users endpoints', () => {
     await seedUser({
       id: userId,
       email: 'unsubscribe-retry@example.org',
+    })
+    await seedGroup({ tenantId: 'unsubscribe-retry', status: 'active' })
+    const member = await seedMember({ tenantId: 'unsubscribe-retry' })
+    const relation = await seedMemberUser({
+      tenantId: 'unsubscribe-retry',
+      memberId: member.id,
+      userId,
       settings: {
-        emails: { group: 'weekly' },
+        notifications: { myAccount: true, group: true },
+        emails: { myAccount: true, group: 'weekly' },
       },
     })
     seedAuthUnsubscribeToken(token, userId, 'unsubscribe-retry@example.org')
@@ -732,13 +679,13 @@ describe('Users endpoints', () => {
       .post(`/users/unsubscribe?token=${token}`)
       .expect(204)
 
-    const userToken = await signJwt(userId, 'unsubscribe-retry@example.org')
-    const settings = await request(app)
-      .get(`/users/${userId}/settings`)
-      .set('Authorization', `Bearer ${userToken}`)
-      .expect(200)
-
-    assert.strictEqual(settings.body.data.attributes.emails.group, 'never')
+    const updated = await tenantDb(prisma, 'unsubscribe-retry').memberUser.findUniqueOrThrow({
+      where: { id: relation.id },
+    })
+    assert.deepStrictEqual(updated.settings, {
+      notifications: { myAccount: true, group: true },
+      emails: { myAccount: true, group: 'never' },
+    })
   })
 
   test('POST /users/unsubscribe rejects missing and unknown tokens', async () => {


### PR DESCRIPTION
### Description

- Adds tenant-scoped list, read, and patch endpoints for member-user relations.
- Moves language create/update operations to the user resource.
- Removes the old user-settings API and the unused member-user role.
- Makes global unsubscribe set newsletter frequency to `never` on every relation for the user.
