### PR TITLE
fix(app): pass group id when deleting pending group

### DIFF
--- a/app/src/pages/superadmin/ManageGroups.vue
+++ b/app/src/pages/superadmin/ManageGroups.vue
@@ -81,7 +81,7 @@
               </confirm-btn>
               <delete-btn
                 color="icon-dark"
-                @confirm="deleteGroup(props.row.code)"
+                @confirm="deleteGroup(props.row.code, props.row.id)"
               >
                 Are you sure you want to delete group {{props.row.name}}?
               </delete-btn>
@@ -209,10 +209,10 @@ const activateGroup = async (code: string) => {
     quasar.loading.hide()
   }
 }
-const deleteGroup = async (code: string) => {
+const deleteGroup = async (code: string, id: string) => {
   await store.dispatch('groups/delete', {
     group: code,
-    id: code
+    id
   })
   await loadGroups()
 }

--- a/app/src/pages/superadmin/ManageGroups.vue
+++ b/app/src/pages/superadmin/ManageGroups.vue
@@ -211,7 +211,8 @@ const activateGroup = async (code: string) => {
 }
 const deleteGroup = async (code: string) => {
   await store.dispatch('groups/delete', {
-    group: code
+    group: code,
+    id: code
   })
   await loadGroups()
 }


### PR DESCRIPTION
Fixes smoke defect DEF009 (SMK-022) by supplying the resource id required by the generic delete action while retaining the group code used by the endpoint. Verified with the production PWA build, 136 Vitest tests, full app lint, and a direct payload check.