### PR TITLE
add gitattributes file to fix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
adds .gitattributes file and code to fix default line endings in in .sh scripts to fix a crash loop when setting up repository in a windows environment